### PR TITLE
add benchmark for forall and curry

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,10 @@
 {
   "name": "moonbitlang/quickcheck",
   "version": "0.8.2",
+  "deps": {
+    "illusory0x0/base": "0.1.0",
+    "moonbitlang/x": "0.4.17"
+  },
   "readme": "README.md",
   "repository": "https://github.com/moonbitlang/quickcheck",
   "license": "Apache-2.0",

--- a/src/internal_benchmark/bm-curry-forall.mbt
+++ b/src/internal_benchmark/bm-curry-forall.mbt
@@ -1,0 +1,49 @@
+///|
+/// 
+/// 
+fn prop_symmetry(x : Array[Int], y : Array[Int]) -> Bool {
+  x == y == (y == x)
+}
+
+///|
+let test_forall : @qc.Property = @qc.forall(@qc.spawn(), fn(x : Array[Int]) {
+  @qc.forall(@qc.spawn(), fn(y : Array[Int]) { prop_symmetry(x, y) })
+})
+
+///|
+let test_curry : @qc.Arrow[Array[Int], @qc.Arrow[Array[Int], Bool]] = prop_symmetry
+  |> @tuple.curry
+  |> @unsafe.coerce
+
+test "forall" {
+  @qc.quick_check!(test_forall)
+}
+
+test "curry" {
+  @qc.quick_check!(test_curry)
+}
+
+test {
+  let crit = @bm.Criterion::new()
+  crit.add(
+    @bm.Task::new("forall", fn() {
+      try {
+        @qc.quick_check!(test_forall)
+      } catch {
+        _ => ()
+      }
+    }),
+  )
+  crit.add(
+    @bm.Task::new("curry", fn() {
+      try {
+        @qc.quick_check!(test_curry)
+      } catch {
+        _ => ()
+      }
+    }),
+  )
+  let r = crit.run()
+  println(r["forall"])
+  println(r["curry"])
+}

--- a/src/internal_benchmark/moon.pkg.json
+++ b/src/internal_benchmark/moon.pkg.json
@@ -1,0 +1,15 @@
+{
+  "import": [
+    {
+      "path": "moonbitlang/quickcheck",
+      "alias": "qc"
+    },
+    {
+      "path": "moonbitlang/x/benchmark",
+      "alias": "bm"
+    },
+    {
+      "path": "illusory0x0/base/unsafe"
+    }
+  ]
+}


### PR DESCRIPTION
The forall version is on average twice as slow as curry.

```moonbit
Some(Benchmark Task [forall] Count = 10
----------------------------------------
Average Time: 0.0027642300000000003s/per test
Max Time Per Test: 0.0017889s/per test
Min Time Per Test: 0.0011173s/per test
----------------------------------------)
Some(Benchmark Task [curry] Count = 10
----------------------------------------
Average Time: 0.00120271s/per test
Max Time Per Test: 0.0014759s/per test
Min Time Per Test: 0.0011208s/per test
----------------------------------------)
```