### PR TITLE
fix readonly constructor

### DIFF
--- a/src/quickcheck.mbti
+++ b/src/quickcheck.mbti
@@ -196,7 +196,7 @@ fn with_max_success[P : Testable](P, Int) -> Property
 fn write_string(Printer, String) -> Unit
 
 // Types and methods
-pub type Arrow[A, B] (A) -> B
+pub(all) type Arrow[A, B] (A) -> B
 impl[P : Testable, A : @moonbitlang/core/quickcheck.Arbitrary + Shrink + Show] Testable for Arrow[A, P]
 
 type Axiom[T]

--- a/src/testable.mbt
+++ b/src/testable.mbt
@@ -2,7 +2,7 @@
 priv type! InternalError String
 
 ///|
-pub type Arrow[A, B] (A) -> B
+pub(all) type Arrow[A, B] (A) -> B
 
 ///|
 typealias RoseRes = Rose[SingleResult]


### PR DESCRIPTION
the newtype `@quickcheck.Arrow` should be `pub(all)`, but it was previously declared as `pub` (readonly). Due to some compiler bug, the issue is not reported. The compiler bug will be fixed in the next release, so this PR fixes the visibility of `@quickcheck.Arrow`