### PR TITLE
Refactor Gen and invariant helpers

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -42,7 +42,7 @@ pub fn[P : Testable] quick_check(
   discard_ratio? : Int,
   expect~ : Expected = Success,
   abort~ : Bool = false
-) -> Unit!Failure {
+) -> Unit raise Failure {
   let prop = map_total_result(prop, fn {
     res =>
       {
@@ -55,7 +55,7 @@ pub fn[P : Testable] quick_check(
         abort,
       }
   })
-  quick_check_with!(Default::default(), prop)
+  quick_check_with(Default::default(), prop)
 }
 
 ///|
@@ -67,8 +67,8 @@ pub fn[A : @quickcheck.Arbitrary + Shrink + Show, B : Testable] quick_check_fn(
   discard_ratio? : Int,
   expect~ : Expected = Success,
   abort~ : Bool = false
-) -> Unit!Failure {
-  quick_check!(
+) -> Unit raise Failure {
+  quick_check(
     Arrow(f),
     max_shrinks?,
     max_success?,
@@ -80,13 +80,16 @@ pub fn[A : @quickcheck.Arbitrary + Shrink + Show, B : Testable] quick_check_fn(
 }
 
 ///|
-pub fn[P : Testable] quick_check_with(cfg : Config, prop : P) -> Unit!Failure {
-  fn f(s : String) -> _!Failure {
-    fail!("\n\{s}")
+pub fn[P : Testable] quick_check_with(
+  cfg : Config,
+  prop : P
+) -> Unit raise Failure {
+  fn f(s : String) -> _ raise Failure {
+    fail("\n\{s}")
   }
 
   try {
-    match quick_check_with_result!(cfg, prop) {
+    match quick_check_with_result(cfg, prop) {
       Success(output~, coverage~, num_tests~) => {
         println(output)
         println(coverage.to_string(num_tests))
@@ -94,10 +97,10 @@ pub fn[P : Testable] quick_check_with(cfg : Config, prop : P) -> Unit!Failure {
     }
   } catch {
     // TODO: Print coverage
-    GaveUp(output~, ..) => f!(output)
+    GaveUp(output~, ..) => f(output)
     Fail(output~, failing_case~, ..) =>
-      f!(output + "\n" + failing_case.join("\n"))
-    NoneExpectedFail(output~, ..) => f!(output)
+      f(output + "\n" + failing_case.join("\n"))
+    NoneExpectedFail(output~, ..) => f(output)
   }
 }
 
@@ -105,27 +108,30 @@ pub fn[P : Testable] quick_check_with(cfg : Config, prop : P) -> Unit!Failure {
 pub fn[P : Testable] quick_check_with_result(
   cfg : Config,
   prop : P
-) -> TestSuccess!TestError {
+) -> TestSuccess raise TestError {
   from_config(cfg).run_test(prop.property())
 }
 
 ///|
-pub fn run_test(self : State, prop : Property) -> TestSuccess!TestError {
-  loop self.run_single_test!(prop) {
+pub fn run_test(self : State, prop : Property) -> TestSuccess raise TestError {
+  loop self.run_single_test(prop) {
     Ok(res) => res
     Err(ns) =>
       if ns.finished_successfully() {
-        ns.complete_test!(prop)
+        ns.complete_test(prop)
       } else if ns.discarded_too_much() {
-        ns.give_up!(prop)
+        ns.give_up(prop)
       } else {
-        continue ns.run_single_test!(prop)
+        continue ns.run_single_test(prop)
       }
   }
 }
 
 ///|
-pub fn complete_test(self : State, _prop : Property) -> TestSuccess!TestError {
+pub fn complete_test(
+  self : State,
+  _prop : Property
+) -> TestSuccess raise TestError {
   if self.expected is Fail {
     raise NoneExpectedFail(
       num_tests=self.num_success_tests,
@@ -143,7 +149,7 @@ pub fn complete_test(self : State, _prop : Property) -> TestSuccess!TestError {
 }
 
 ///|
-pub fn give_up(self : State, _prop : Property) -> TestSuccess!TestError {
+pub fn give_up(self : State, _prop : Property) -> TestSuccess raise TestError {
   if self.expected is GaveUp {
     Success(
       num_tests=self.num_success_tests,
@@ -164,18 +170,18 @@ pub fn give_up(self : State, _prop : Property) -> TestSuccess!TestError {
 pub fn run_single_test(
   self : State,
   prop : Property
-) -> Result[TestSuccess, State]!TestError {
+) -> Result[TestSuccess, State] raise TestError {
   let rnd1 = self.random_state.split()
   let rnd2 = self.random_state
-  let { val: res, branch: ts } = prop._.run(self.compute_size(), rnd1)
+  let { val: res, branch: ts } = prop.inner().run(self.compute_size(), rnd1)
   fn next(
-    end_with : (State, Property) -> TestSuccess!TestError,
+    end_with : (State, Property) -> TestSuccess raise TestError,
     next_state : State,
     p : Property
-  ) -> Result[TestSuccess, State]!TestError {
+  ) -> Result[TestSuccess, State] raise TestError {
     update_state(next_state)
     if res.abort {
-      end_with!(next_state, p) |> Ok
+      end_with(next_state, p) |> Ok
     } else {
       Err(next_state)
     }
@@ -191,7 +197,7 @@ pub fn run_single_test(
   self.callback_post_test(res)
   match res {
     { ok: Some(true), .. } =>
-      next!(
+      next(
         State::complete_test,
         {
           ..stc,
@@ -200,9 +206,9 @@ pub fn run_single_test(
         },
         prop,
       )
-    { ok: Some(false), .. } => Ok(self.find_failure!(res, ts))
+    { ok: Some(false), .. } => Ok(self.find_failure(res, ts))
     { ok: None, .. } =>
-      next!(
+      next(
         State::give_up,
         {
           ..self,
@@ -219,7 +225,7 @@ pub fn find_failure(
   self : State,
   res : SingleResult,
   ts : Iter[Rose[SingleResult]]
-) -> TestSuccess!TestError {
+) -> TestSuccess raise TestError {
   let (n, tf, lf, ce) = { ..self, num_try_shrinks: 0 }.local_min(res, ts)
   match res.expect {
     Success | GaveUp =>

--- a/src/falsify/property.mbt
+++ b/src/falsify/property.mbt
@@ -80,6 +80,7 @@ pub fn[T : Show, E] collect(l : String, ls : List[T]) -> Property[Unit, E] {
 }
 
 // Running Generators
+
 ///|
 pub fn[T, E] gen(f : (T) -> String?, g : Gen[T]) -> Property[T, E] {
   fn aux(run : TestRun) -> (T) -> (TestResult[T, E], TestRun) {

--- a/src/falsify/selective.mbt
+++ b/src/falsify/selective.mbt
@@ -1,4 +1,5 @@
 // Selective Applicative Functor
+
 ///|
 enum Either[L, R] {
   Left(L)

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -49,13 +49,13 @@ pub fn[T] Gen::samples(
 
 ///| Helper function for feat_random
 fn[T] feat_helper(enumerate : @feat.Enumerate[T], size : Int) -> Gen[T] {
-  loop enumerate.parts, size {
-    @lazy.Nil, _ => abort("uniform: empty enumeration")
-    parts, bound => {
+  loop (enumerate.parts, size) {
+    (@lazy.Nil, _) => abort("uniform: empty enumeration")
+    (parts, bound) => {
       let (incl, rest) = parts.split_at(bound)
       let fin = @feat.fin_mconcat(incl)
       match fin.fCard {
-        0 => continue rest, 1
+        0 => continue (rest, 1)
         _ => break integer_bound(fin.fCard).fmap(fn(i) { (fin.fIndex)(i) })
       }
     }
@@ -209,21 +209,20 @@ pub fn[T] resize(self : Gen[T], size : Int) -> Gen[T] {
 ///| Attempt to generate a value that satisfies a predicate
 /// If failures reach the maximum size, return None
 pub fn[T] such_that_maybe(self : Gen[T], pred : (T) -> Bool) -> Gen[T?] {
-  fn attempt {
-    m, n =>
-      if m > n {
-        pure(None)
-      } else {
-        self
-        .resize(m)
-        .bind(fn(x) {
-          if pred(x) {
-            x |> Some |> pure
-          } else {
-            attempt(m + 1, n)
-          }
-        })
-      }
+  fn attempt(m, n) {
+    if m > n {
+      pure(None)
+    } else {
+      self
+      .resize(m)
+      .bind(fn(x) {
+        if pred(x) {
+          x |> Some |> pure
+        } else {
+          attempt(m + 1, n)
+        }
+      })
+    }
   }
 
   sized(fn(n) { attempt(n, 2 * n) })
@@ -233,9 +232,11 @@ pub fn[T] such_that_maybe(self : Gen[T], pred : (T) -> Bool) -> Gen[T?] {
 pub fn[T] such_that(self : Gen[T], pred : (T) -> Bool) -> Gen[T] {
   self
   .such_that_maybe(pred)
-  .bind(fn {
-    None => sized(fn { n => self.such_that(pred).resize(n + 1) })
-    Some(x) => pure(x)
+  .bind(fn(res) {
+    match res {
+      None => sized(fn(n) { self.such_that(pred).resize(n + 1) })
+      Some(x) => pure(x)
+    }
   })
 }
 
@@ -245,7 +246,7 @@ pub fn[T] frequency(arr : Array[(Int, Gen[T])]) -> Gen[T] {
   if arr.is_empty() {
     abort("frequency: empty array")
   } else {
-    let sum = arr.map(@tuple.fst).fold(Int::op_add, init=0)
+    let sum = arr.map(fn(t) { t.0 }).fold(Int::op_add, init=0)
     if sum < 1 {
       abort("frequency: total weight is less than 1")
     } else {
@@ -400,12 +401,12 @@ pub fn char_range(lo : Char, hi : Char) -> Gen[Char] {
 
 ///|
 pub fn[T] list_with_size(size : Int, gen : Gen[T]) -> Gen[@immut/list.T[T]] {
-  loop size, pure(@immut/list.Nil) {
-    n, acc =>
+  loop (size, pure(@immut/list.Nil)) {
+    (n, acc) =>
       if n <= 0 {
         break acc
       } else {
-        continue n - 1, liftA2(@immut/list.T::Cons(_, _), gen, acc)
+        continue (n - 1, liftA2(@immut/list.T::Cons(_, _), gen, acc))
       }
   }
 }

--- a/src/internal_benchmark/bm-curry-forall-tuple.mbt
+++ b/src/internal_benchmark/bm-curry-forall-tuple.mbt
@@ -1,7 +1,7 @@
 ///|
 /// 
 fn prop_symmetry(x : Array[Int], y : Array[Int]) -> Bool {
-  x == y == (y == x)
+  (x == y) == (y == x)
 }
 
 ///|
@@ -20,10 +20,10 @@ let test_curry : @qc.Arrow[Array[Int], @qc.Arrow[Array[Int], Bool]] = prop_symme
   |> coerce
 
 ///|
-let test_tuple : @qc.Arrow[(Array[Int], Array[Int]), Bool] = fn(p) {
+let test_tuple : @qc.Arrow[(Array[Int], Array[Int]), Bool] = (fn(p) {
     let (x, y) = p
     prop_symmetry(x, y)
-  }
+  })
   |> @qc.Arrow
 
 ///|

--- a/src/invariant.mbt
+++ b/src/invariant.mbt
@@ -1,45 +1,57 @@
 ///| Extensional equality for function.
 pub fn[A, B : Eq] ext_equal(f : (A) -> B, g : (A) -> B) -> (A) -> Bool {
-  fn { x => f(x) == g(x) }
+  fn(x) { f(x) == g(x) }
 }
 
 ///| Idempotent function.
 pub fn[A : Eq] idempotent(f : (A) -> A) -> (A) -> Bool {
-  fn { x => f(f(x)) == f(x) }
+  fn(x) { f(f(x)) == f(x) }
 }
 
 ///| Involutory function.
 pub fn[A : Eq] involutory(f : (A) -> A) -> (A) -> Bool {
-  fn { x => f(f(x)) == x }
+  fn(x) { f(f(x)) == x }
 }
 
 ///| Inverse function.
 pub fn[A : Eq, B] inverse(f : (A) -> B, g : (B) -> A) -> (A) -> Bool {
-  fn { x => g(f(x)) == x }
+  fn(x) { g(f(x)) == x }
 }
 
 ///| Monotonic increasing function.
 pub fn[A : Compare, B : Compare] mono_increase(
   f : (A) -> B
 ) -> ((A, A)) -> Bool {
-  fn { (x, y) => x <= y && f(x) <= f(y) }
+  fn(t : (A, A)) {
+    let (x, y) = t
+    x <= y && f(x) <= f(y)
+  }
 }
 
 ///| Monotonic decreasing function.
 pub fn[A : Compare, B : Compare] mono_decrease(
   f : (A) -> B
 ) -> ((A, A)) -> Bool {
-  fn { (x, y) => x <= y && f(x) >= f(y) }
+  fn(t : (A, A)) {
+    let (x, y) = t
+    x <= y && f(x) >= f(y)
+  }
 }
 
 ///| Commutative binary operation.
 pub fn[A, B : Eq] commutative(f : (A, A) -> B) -> ((A, A)) -> Bool {
-  fn { (x, y) => f(x, y) == f(y, x) }
+  fn(t : (A, A)) {
+    let (x, y) = t
+    f(x, y) == f(y, x)
+  }
 }
 
 ///| Associative binary operation.
 pub fn[A : Eq] associative(f : (A, A) -> A) -> ((A, A, A)) -> Bool {
-  fn { (x, y, z) => f(f(x, y), z) == f(x, f(y, z)) }
+  fn(t : (A, A, A)) {
+    let (x, y, z) = t
+    f(f(x, y), z) == f(x, f(y, z))
+  }
 }
 
 ///| Distributive binary operation over left
@@ -47,7 +59,10 @@ pub fn[A : Eq] distributive_left(
   f : (A, A) -> A,
   g : (A, A) -> A
 ) -> ((A, A, A)) -> Bool {
-  fn { (x, y, z) => f(x, g(y, z)) == g(f(x, y), f(x, z)) }
+  fn(t : (A, A, A)) {
+    let (x, y, z) = t
+    f(x, g(y, z)) == g(f(x, y), f(x, z))
+  }
 }
 
 ///| Distributive binary operation over right
@@ -55,5 +70,8 @@ pub fn[A : Eq] distributive_right(
   f : (A, A) -> A,
   g : (A, A) -> A
 ) -> ((A, A, A)) -> Bool {
-  fn { (x, y, z) => f(g(x, y), z) == g(f(x, z), f(y, z)) }
+  fn(t : (A, A, A)) {
+    let (x, y, z) = t
+    f(g(x, y), z) == g(f(x, z), f(y, z))
+  }
 }

--- a/src/result.mbt
+++ b/src/result.mbt
@@ -5,6 +5,7 @@ pub(all) enum Outcome[T] {
   Fail(T) // Counterexample
 }
 
+///|
 pub(all) enum Expected {
   Fail
   Success

--- a/src/rose/rose.mbt
+++ b/src/rose/rose.mbt
@@ -1,4 +1,5 @@
 // Rose Tree used for shrinking
+
 ///|
 pub(all) struct Rose[T] {
   val : T

--- a/src/shrink.mbt
+++ b/src/shrink.mbt
@@ -19,8 +19,8 @@ impl Shrink for Int with shrink(x) {
 
 ///|
 test "shrink int" {
-  inspect!(Shrink::shrink(100), content="[99, 97, 94, 88, 75, 50, 0]")
-  inspect!(Shrink::shrink(0), content="[]")
+  inspect(Shrink::shrink(100), content="[99, 97, 94, 88, 75, 50, 0]")
+  inspect(Shrink::shrink(0), content="[]")
 }
 
 ///|
@@ -34,7 +34,7 @@ impl Shrink for Int64 with shrink(x) {
 
 ///|
 test "shrink int64" {
-  inspect!(
+  inspect(
     Shrink::shrink(10000L),
     content="[9999, 9998, 9996, 9991, 9981, 9961, 9922, 9844, 9688, 9375, 8750, 7500, 5000, 0]",
   )
@@ -51,7 +51,7 @@ impl Shrink for UInt with shrink(x) {
 
 ///|
 test "shrink uint" {
-  inspect!(
+  inspect(
     Shrink::shrink(37000U),
     content="[36999, 36998, 36996, 36991, 36982, 36964, 36928, 36856, 36711, 36422, 35844, 34688, 32375, 27750, 18500, 0]",
   )
@@ -68,7 +68,7 @@ impl Shrink for UInt64 with shrink(x) {
 
 ///|
 test "shrink uint64" {
-  inspect!(
+  inspect(
     Shrink::shrink((42000 : UInt64)),
     content="[41999, 41998, 41995, 41990, 41980, 41959, 41918, 41836, 41672, 41344, 40688, 39375, 36750, 31500, 21000, 0]",
   )
@@ -86,8 +86,8 @@ impl Shrink for Bool with shrink(b) {
 
 ///|
 test "shrink boolean" {
-  inspect!(Shrink::shrink(true), content="[false]")
-  inspect!(Shrink::shrink(false), content="[]")
+  inspect(Shrink::shrink(true), content="[false]")
+  inspect(Shrink::shrink(false), content="[]")
 }
 
 ///|
@@ -103,7 +103,7 @@ impl Shrink for Char with shrink(c) {
 
 ///|
 test "shrink char" {
-  inspect!(
+  inspect(
     Shrink::shrink('测'),
     content="['浊', '浌', 'a', 'A', '1', '\\n', '\\t', '\\b', '\\\\', '\\'', '\\r', ' ']",
   )
@@ -119,13 +119,14 @@ impl[T : Shrink] Shrink for T? with shrink(x) {
 }
 
 ///|
+
 ///|
 impl Shrink for Unit
 
 ///|
 test "shrink option" {
-  inspect!(Shrink::shrink((None : Unit?)), content="[]")
-  inspect!(
+  inspect(Shrink::shrink((None : Unit?)), content="[]")
+  inspect(
     Shrink::shrink(Some(1000)),
     content="[Some(999), Some(997), Some(993), Some(985), Some(969), Some(938), Some(875), Some(750), Some(500), Some(0), None]",
   )
@@ -143,11 +144,11 @@ impl[T : Shrink, E : Shrink] Shrink for Result[T, E] with shrink(x) {
 test "shrink result" {
   let b : Result[Bool, Int] = Err(100)
   let x : Result[Bool, Int] = Ok(true)
-  inspect!(
+  inspect(
     Shrink::shrink(b),
     content="[Err(99), Err(97), Err(94), Err(88), Err(75), Err(50), Err(0)]",
   )
-  inspect!(Shrink::shrink(x), content="[Ok(false)]")
+  inspect(Shrink::shrink(x), content="[Ok(false)]")
 }
 
 ///|
@@ -161,7 +162,7 @@ impl[A : Shrink, B : Shrink] Shrink for (A, B) with shrink(x) {
 ///|
 test "shrink tuple" {
   let x = (120, true)
-  inspect!(
+  inspect(
     Shrink::shrink(x),
     content="[(119, true), (117, true), (113, true), (105, true), (90, true), (60, true), (0, true), (120, false)]",
   )
@@ -221,7 +222,7 @@ impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink] Shr
 ///|
 test "shrink 6-tuple" {
   let x = (20, 'A', 30U, true, true, true)
-  inspect!(
+  inspect(
     Shrink::shrink(x),
     content="[(19, 'A', 30, true, true, true), (18, 'A', 30, true, true, true), (15, 'A', 30, true, true, true), (10, 'A', 30, true, true, true), (0, 'A', 30, true, true, true), (20, '@', 30, true, true, true), (20, 'B', 30, true, true, true), (20, 'a', 30, true, true, true), (20, 'A', 30, true, true, true), (20, '1', 30, true, true, true), (20, '\\n', 30, true, true, true), (20, '\\t', 30, true, true, true), (20, '\\b', 30, true, true, true), (20, '\\\\', 30, true, true, true), (20, '\\'', 30, true, true, true), (20, '\\r', 30, true, true, true), (20, ' ', 30, true, true, true), (20, 'A', 29, true, true, true), (20, 'A', 27, true, true, true), (20, 'A', 23, true, true, true), (20, 'A', 15, true, true, true), (20, 'A', 0, true, true, true), (20, 'A', 30, false, true, true), (20, 'A', 30, true, false, true), (20, 'A', 30, true, true, false)]",
   )
@@ -251,7 +252,7 @@ impl[T : Shrink] Shrink for @immut/list.T[T] with shrink(xs) {
 test "shrink int list" {
   let il : @immut/list.T[Int] = @immut/list.of([1, 2, 3, 4, 5, 6])
   let s = Shrink::shrink(il)
-  inspect!(
+  inspect(
     s,
     content="[@list.of([2, 3, 4, 5, 6]), @list.of([1, 3, 4, 5, 6]), @list.of([1, 2, 4, 5, 6]), @list.of([1, 2, 3, 5, 6]), @list.of([1, 2, 3, 4, 6]), @list.of([4, 5, 6]), @list.of([0, 2, 3, 4, 5, 6]), @list.of([1, 1, 3, 4, 5, 6]), @list.of([1, 0, 3, 4, 5, 6]), @list.of([1, 2, 2, 4, 5, 6]), @list.of([1, 2, 0, 4, 5, 6]), @list.of([1, 2, 3, 3, 5, 6]), @list.of([1, 2, 3, 2, 5, 6]), @list.of([1, 2, 3, 0, 5, 6]), @list.of([1, 2, 3, 4, 4, 6]), @list.of([1, 2, 3, 4, 3, 6]), @list.of([1, 2, 3, 4, 0, 6]), @list.of([1, 2, 3, 4, 5, 5]), @list.of([1, 2, 3, 4, 5, 3]), @list.of([1, 2, 3, 4, 5, 0])]",
   )
@@ -282,7 +283,7 @@ impl[X : Shrink] Shrink for Array[X] with shrink(xs) {
 test "shrink array" {
   let ar = [1, 2, 3, 4, 5, 6]
   let s = Shrink::shrink(ar)
-  inspect!(
+  inspect(
     s,
     content="[[2, 3, 4, 5, 6], [1, 3, 4, 5, 6], [1, 2, 4, 5, 6], [1, 2, 3, 5, 6], [1, 2, 3, 4, 6], [4, 5, 6], [0, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 0, 3, 4, 5, 6], [1, 2, 2, 4, 5, 6], [1, 2, 0, 4, 5, 6], [1, 2, 3, 3, 5, 6], [1, 2, 3, 2, 5, 6], [1, 2, 3, 0, 5, 6], [1, 2, 3, 4, 4, 6], [1, 2, 3, 4, 3, 6], [1, 2, 3, 4, 0, 6], [1, 2, 3, 4, 5, 5], [1, 2, 3, 4, 5, 3], [1, 2, 3, 4, 5, 0]]",
   )
@@ -311,7 +312,7 @@ impl[X : Shrink] Shrink for Iter[X] with shrink(xs) {
 ///|
 test "shrink iter" {
   let it = [1, 2, 3, 4, 5, 6].iter()
-  inspect!(
+  inspect(
     Shrink::shrink(it),
     content="[[2, 3, 4, 5, 6], [1, 3, 4, 5, 6], [1, 2, 4, 5, 6], [1, 2, 3, 5, 6], [1, 2, 3, 4, 6], [1, 2, 3, 4, 5], [0, 2, 3, 4, 5, 6], [1, 1, 3, 4, 5, 6], [1, 0, 3, 4, 5, 6], [1, 2, 2, 4, 5, 6], [1, 2, 0, 4, 5, 6], [1, 2, 3, 3, 5, 6], [1, 2, 3, 2, 5, 6], [1, 2, 3, 0, 5, 6], [1, 2, 3, 4, 4, 6], [1, 2, 3, 4, 3, 6], [1, 2, 3, 4, 0, 6], [1, 2, 3, 4, 5, 5], [1, 2, 3, 4, 5, 3], [1, 2, 3, 4, 5, 0]]",
   )

--- a/src/state.mbt
+++ b/src/state.mbt
@@ -114,12 +114,14 @@ fn from_config(cfg : Config) -> State {
 }
 
 // Deep copy of the state
+
 ///|
 fn clone(self : State) -> State {
   { ..self }
 }
 
 // Computes the test size from the state
+
 ///|
 fn compute_size(self : State) -> Int {
   match self {
@@ -213,7 +215,7 @@ priv type ListCompare[T] List[T] derive(Eq, Show)
 
 ///|
 impl[T : Compare] Compare for ListCompare[T] with compare(self, other) {
-  match (self._, other._) {
+  match (self.inner(), other.inner()) {
     (Cons(x, xs), Cons(y, ys)) => {
       let res = T::compare(x, y)
       if res == 0 {
@@ -269,10 +271,10 @@ fn class_incr(self : Coverage, classes : List[(String, Bool)]) -> Unit {
 fn label_to_string(self : Coverage, success : Int) -> String {
   let res = []
   self.labels.each(fn(list, i) {
-    if list._.is_empty() {
+    if list.inner().is_empty() {
       return
     } else {
-      let l = list._.to_array().join(", ")
+      let l = list.inner().to_array().join(", ")
       res.push("\{i.to_double() / success.to_double () * 100}% : \{l}")
     }
   })

--- a/src/testable.mbt
+++ b/src/testable.mbt
@@ -5,7 +5,7 @@ priv suberror InternalError String
 pub(all) type Arrow[A, B] (A) -> B
 
 ///|
-typealias RoseRes = Rose[SingleResult]
+typealias Rose[SingleResult] as RoseRes
 
 ///|
 typealias @rose.Rose
@@ -83,12 +83,12 @@ pub impl[P : Testable, A : @quickcheck.Arbitrary + Shrink + Show] Testable for A
   A,
   P,
 ] with property(self) {
-  forall_shrink(Gen::spawn(), A::shrink, self._)
+  forall_shrink(Gen::spawn(), A::shrink, self.inner())
 }
 
 ///|
 pub fn[P : Testable] run_prop(prop : P) -> Gen[Rose[SingleResult]] {
-  prop.property()._
+  prop.property().inner()
 }
 
 ///|
@@ -184,7 +184,7 @@ pub fn[T : Testable, A : Show] forall_shrink(
     shrinking(shrinker, x, fn(a : A) {
       let s = a.to_string()
       counterexample(f(a), s)
-    })._
+    }).inner()
   })
 }
 

--- a/src/testing/driver.mbt
+++ b/src/testing/driver.mbt
@@ -24,37 +24,37 @@ fn prop_rev(l : List[Int]) -> Bool {
 ///|
 test "prop reverse (fail)" {
   let prop_rev = fn(l : List[Int]) { l.rev().rev() == l.rev() }
-  @qc.quick_check!(prop_rev |> @qc.Arrow, expect=Fail)
+  @qc.quick_check(prop_rev |> @qc.Arrow, expect=Fail)
 }
 
 ///|
 test "prop reverse" {
-  @qc.quick_check_fn!(prop_rev)
+  @qc.quick_check_fn(prop_rev)
 }
 
 ///|
 test "add comm double" {
-  @qc.quick_check_fn!(add_comm_double)
+  @qc.quick_check_fn(add_comm_double)
 }
 
 ///|
 test "modify max tests" {
-  @qc.quick_check!(@qc.Arrow(prop_rev), max_success=1000)
+  @qc.quick_check(@qc.Arrow(prop_rev), max_success=1000)
 }
 
 ///|
 test "large max tests" {
-  @qc.quick_check!((), max_success=2000)
+  @qc.quick_check((), max_success=2000)
 }
 
 ///|
 test "larger max tests" {
-  @qc.quick_check!((), max_success=10000)
+  @qc.quick_check((), max_success=10000)
 }
 
 ///|
 test "add assoc double (expect fail)" {
-  @qc.quick_check!(@qc.Arrow(add_assoc_double), expect=Fail)
+  @qc.quick_check(@qc.Arrow(add_assoc_double), expect=Fail)
 }
 
 ///|
@@ -62,19 +62,19 @@ test "non empty list (with filter)" {
   let prop_is_non_empty = fn(l : List[Int]) {
     not(l.is_empty()) |> @qc.filter(not(l.is_empty()))
   }
-  @qc.quick_check!(@qc.Arrow(prop_is_non_empty))
+  @qc.quick_check(@qc.Arrow(prop_is_non_empty))
 }
 
 ///|
 test "reject all" {
   let prop_reject = fn(_x : Int) { @qc.filter(true, false) }
-  @qc.quick_check!(@qc.Arrow(prop_reject), expect=GaveUp)
+  @qc.quick_check(@qc.Arrow(prop_reject), expect=GaveUp)
 }
 
 ///|
 test "label" {
   let ar : @qc.Arrow[@immut/list.T[Int], Bool] = @qc.Arrow(prop_rev)
-  @qc.quick_check!(
+  @qc.quick_check(
     @qc.Arrow(fn(x : List[Int]) {
       @qc.label(ar, if x.is_empty() { "trivial" } else { "non-trivial" })
     }),
@@ -83,7 +83,7 @@ test "label" {
 
 ///|
 test "classes" {
-  @qc.quick_check_fn!(fn(x : List[Int]) {
+  @qc.quick_check_fn(fn(x : List[Int]) {
     @qc.Arrow(prop_rev)
     |> @qc.classify(x.length() > 5, "long list")
     |> @qc.classify(x.length() <= 5, "short list")
@@ -92,7 +92,7 @@ test "classes" {
 
 ///|
 test "label + classes" {
-  @qc.quick_check_fn!(fn(x : List[String]) {
+  @qc.quick_check_fn(fn(x : List[String]) {
     @qc.Arrow(prop_rev)
     |> @qc.classify(x.length() > 5, "long list")
     |> @qc.classify(x.length() <= 5, "short list")
@@ -102,7 +102,7 @@ test "label + classes" {
 
 ///|
 test "abort" {
-  @qc.quick_check!(@qc.Arrow(prop_rev), abort=true)
+  @qc.quick_check(@qc.Arrow(prop_rev), abort=true)
 }
 
 ///| Natural Numbers
@@ -148,7 +148,7 @@ fn add_comm_nat(ab : (Nat, Nat)) -> Bool {
 
 ///|
 test "add comm nat" {
-  @qc.quick_check_fn!(add_comm_nat)
+  @qc.quick_check_fn(add_comm_nat)
 }
 
 ///|
@@ -158,8 +158,8 @@ fn[T] reverse(lst : Array[T]) -> Array[T] {
 
 ///|
 test "reverse" {
-  inspect!(reverse(([] : Array[Int])), content="[]")
-  inspect!(reverse([1, 2, 3]), content="[3, 2, 1]")
+  inspect(reverse(([] : Array[Int])), content="[]")
+  inspect(reverse([1, 2, 3]), content="[3, 2, 1]")
 }
 
 ///|
@@ -168,7 +168,7 @@ test "prop_reverse_identity" {
     reverse(reverse(arr)) == arr
   }
 
-  @qc.quick_check!(@qc.Arrow(prop_reverse_identity))
+  @qc.quick_check(@qc.Arrow(prop_reverse_identity))
 }
 
 ///|
@@ -195,12 +195,12 @@ fn prop_length_is_not_greater(iarr : (Int, Array[Int])) -> Bool {
 
 ///|
 test "prop length is not greater" {
-  @qc.quick_check!(@qc.Arrow(prop_length_is_not_greater))
+  @qc.quick_check(@qc.Arrow(prop_length_is_not_greater))
 }
 
 ///|
 test "prop remove not presence with max success" {
-  @qc.quick_check!(
+  @qc.quick_check(
     @qc.Arrow(prop_remove_not_presence),
     max_success=1000,
     expect=Fail,
@@ -209,7 +209,7 @@ test "prop remove not presence with max success" {
 
 ///|
 test "custom generator" {
-  @qc.quick_check!(
+  @qc.quick_check(
     @qc.forall(@qc.Gen::spawn(), fn(i_arr : (Int, Array[Int])) {
       let (x, arr) = i_arr
       not(remove(arr, x).contains(x))
@@ -224,7 +224,7 @@ test "no_duplicate" {
     @sorted_set.from_iter(x.iter()).size() == x.length()
   }
 
-  @qc.quick_check!(
+  @qc.quick_check(
     @qc.forall(@qc.Gen::spawn(), fn(iarr : (Int, Array[Int])) {
       let (x, arr) = iarr
       not(remove(arr.copy(), x).contains(x)) |> @qc.filter(no_duplicate(arr))
@@ -235,7 +235,7 @@ test "no_duplicate" {
 
 ///|
 test "use one_of" {
-  @qc.quick_check!(
+  @qc.quick_check(
     @qc.forall(@qc.Gen::spawn(), fn(a : Array[Int]) {
       @qc.forall(@qc.one_of_array(a), fn(y : Int) {
         not(remove(a, y).contains(y))
@@ -248,7 +248,7 @@ test "use one_of" {
 
 ///|
 test "explicit universal qualification" {
-  @qc.quick_check!(
+  @qc.quick_check(
     @qc.forall(@qc.Gen::spawn(), fn(x : List[Int]) { x.rev().rev() == x }),
   )
 }

--- a/src/testing/gen.mbt
+++ b/src/testing/gen.mbt
@@ -1,7 +1,7 @@
 ///|
 test "feat int" {
   let fe : @qc.Gen[Int] = @qc.Gen::feat_random(10)
-  inspect!(
+  inspect(
     fe.samples(size=50),
     content="[-3, 2, 3, -1, 2, -1, -4, 5, 0, 2, -4, 2, -2, -2, -5, 2, -3, 0, 1, 0, 1, -4, -2, -1, 2, -2, -2, -4, 0, 1, 0, 3, 0, 2, 3, 0, -2, -2, 1, -1, -1, -4, -1, 0, -2, -4, 0, 0, -2, -1]",
   )
@@ -10,7 +10,7 @@ test "feat int" {
 ///|
 test "feat nat" {
   let fe : @qc.Gen[Nat] = @qc.Gen::feat_random(21)
-  inspect!(
+  inspect(
     fe.samples(size=20),
     content="[Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))))), Zero, Succ(Succ(Succ(Succ(Zero)))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))))))))))))), Succ(Succ(Zero)), Succ(Succ(Zero)), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))), Succ(Succ(Succ(Succ(Zero)))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))))))))))), Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))), Succ(Succ(Succ(Zero))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))))))))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))))))))), Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))))), Succ(Succ(Succ(Succ(Zero))))]",
   )
@@ -21,7 +21,7 @@ test "feat nat index" {
   let x = [0N, 1, 2, 3, 4, 5, 6].map(fn(x) {
     (@feat.Enumerable::enumerate() : @feat.Enumerate[Nat]).en_index(x)
   })
-  inspect!(
+  inspect(
     x,
     content="[Zero, Succ(Zero), Succ(Succ(Zero)), Succ(Succ(Succ(Zero))), Succ(Succ(Succ(Succ(Zero)))), Succ(Succ(Succ(Succ(Succ(Zero))))), Succ(Succ(Succ(Succ(Succ(Succ(Zero))))))]",
   )
@@ -77,7 +77,7 @@ impl[E : @feat.Enumerable] @feat.Enumerable for Tree[E] with enumerate() {
 ///|
 test "feat tree random" {
   let tg : @qc.Gen[Tree[Nat]] = @qc.Gen::feat_random(10)
-  inspect!(
+  inspect(
     tg.samples(),
     content="[Leaf(Succ(Succ(Succ(Succ(Succ(Succ(Succ(Zero)))))))), Leaf(Succ(Succ(Succ(Succ(Zero))))), Branch({forest: @list.of([Leaf(Succ(Succ(Zero)))])}), Leaf(Succ(Succ(Succ(Succ(Succ(Zero)))))), Leaf(Succ(Succ(Succ(Zero)))), Branch({forest: @list.of([Branch({forest: @list.of([])})])}), Leaf(Succ(Succ(Zero))), Branch({forest: @list.of([Leaf(Succ(Zero))])}), Leaf(Succ(Succ(Succ(Succ(Succ(Zero)))))), Branch({forest: @list.of([Branch({forest: @list.of([])})])})]",
   )
@@ -86,9 +86,9 @@ test "feat tree random" {
 ///|
 test "feat tree" {
   let fe : @qc.Gen[Tree[Nat]] = @qc.Gen::feat_random(11)
-  inspect!(fe.sample(), content="Leaf(Succ(Succ(Succ(Succ(Zero)))))")
+  inspect(fe.sample(), content="Leaf(Succ(Succ(Succ(Succ(Zero)))))")
   let x : SingleTree = @feat.Enumerable::enumerate().en_index(196606)
-  inspect!(
+  inspect(
     x,
     content="Node(false, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Leaf(true)))))))))))))))))",
   )
@@ -104,7 +104,7 @@ test "index large" {
 
 ///|
 test "nat" {
-  inspect!(
+  inspect(
     @qc.nat().samples(size=50),
     content="[4, -93, 2, 4, 92, 0, 6, 7, -90, 0, -6, -92, 0, 70, 96, -7, 816, 6, 229, 6, 4, -5, -1, -163, -93, -231, -18, 6, -74, 5, 618, 206, -12, -2, 1, 3, 5, 2, 83, -6, 8, -8, -3, -676, -5, -31, -2, -514, -61, -6]",
   )
@@ -112,7 +112,7 @@ test "nat" {
 
 ///|
 test "small int" {
-  inspect!(
+  inspect(
     @qc.small_int().samples(size=50),
     content="[6, -7, 5, 0, 10, -10, 0, 7, -5, -1, -5, -4, 0, 3, 7, -5, 42, 3, 78, 1, 10, -5, -10, -51, -5, -73, -1, 3, -1, 9, 22, 88, -2, -7, 3, 9, 7, 1, 1, -1, 6, -9, -7, -25, -1, -10, -6, -33, -1, -4]",
   )
@@ -120,7 +120,7 @@ test "small int" {
 
 ///|
 test "frequency int" {
-  inspect!(
+  inspect(
     @qc.frequency([(4, @qc.pure(42)), (1, @qc.pure(37)), (3, @qc.pure(114))]).samples(
       size=50,
     ),
@@ -130,7 +130,7 @@ test "frequency int" {
 
 ///|
 test "one of" {
-  inspect!(
+  inspect(
     @qc.one_of([1, 2, 3, 4].map(@qc.pure)).samples(size=50),
     content="[1, 3, 2, 1, 4, 3, 3, 1, 3, 1, 4, 1, 4, 3, 1, 4, 2, 3, 1, 2, 3, 1, 2, 2, 3, 4, 3, 1, 2, 4, 1, 3, 3, 2, 3, 3, 2, 1, 1, 2, 3, 1, 3, 3, 1, 3, 2, 4, 1, 4]",
   )
@@ -138,7 +138,7 @@ test "one of" {
 
 ///|
 test "one of array" {
-  inspect!(
+  inspect(
     @qc.one_of_array(["a", "b", "c"]).samples(size=50),
     content=
       #|["a", "a", "b", "a", "c", "a", "b", "a", "c", "b", "c", "c", "a", "a", "c", "b", "b", "a", "b", "a", "c", "a", "a", "b", "b", "c", "b", "a", "b", "a", "b", "a", "c", "b", "c", "c", "c", "b", "a", "c", "a", "a", "a", "a", "b", "b", "a", "b", "c", "b"]
@@ -148,7 +148,7 @@ test "one of array" {
 
 ///|
 test "char range" {
-  inspect!(
+  inspect(
     @qc.char_range('a', 'c').samples(size=20),
     content="['a', 'a', 'b', 'a', 'c', 'a', 'b', 'a', 'c', 'b', 'c', 'c', 'a', 'a', 'c', 'b', 'b', 'a', 'b', 'a']",
   )
@@ -157,7 +157,7 @@ test "char range" {
 ///|
 test "one_of" {
   let gen_bool : @qc.Gen[Bool] = @qc.one_of([@qc.pure(true), @qc.pure(false)])
-  inspect!(
+  inspect(
     gen_bool.samples(size=10),
     content="[true, true, false, true, false, true, true, true, true, true]",
   )
@@ -169,7 +169,7 @@ test "frequency" {
     (4, @qc.pure(true)),
     (1, @qc.pure(false)),
   ])
-  inspect!(
+  inspect(
     gen_freq.samples(size=20),
     content="[true, true, true, true, true, true, true, true, true, true, true, true, true, false, true, true, true, true, true, true]",
   )
@@ -179,5 +179,5 @@ test "frequency" {
 test "sized trivial" {
   let gen : @qc.Gen[Int] = @qc.sized(@qc.pure)
   let arr = Array::makei(10, fn { i => gen.sample(size=i) })
-  inspect!(arr, content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")
+  inspect(arr, content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")
 }

--- a/src/utils/common.mbt
+++ b/src/utils/common.mbt
@@ -2,6 +2,7 @@
 let global_counter : Ref[Int] = @ref.new(0)
 
 // Generate a fresh name
+
 ///|
 pub fn fresh_name() -> String {
   let counter = global_counter.val


### PR DESCRIPTION
## Summary
- modernize syntax in `gen.mbt` loops and lambdas
- rewrite `invariant.mbt` helpers with clearer tuple handling

## Testing
- `moon info`
- `moon test`
- `moon check`

------
https://chatgpt.com/codex/tasks/task_e_685b3a38071483209edb661896e6c41d