### PR TITLE
Fix deprecated syntax warnings

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -43,17 +43,16 @@ pub fn[P : Testable] quick_check(
   expect~ : Expected = Success,
   abort~ : Bool = false
 ) -> Unit raise Failure {
-  let prop = map_total_result(prop, fn {
-    res =>
-      {
-        ..res,
-        maybe_num_tests: max_success,
-        maybe_max_test_size: max_size,
-        maybe_max_shrinks: max_shrinks,
-        maybe_discarded_ratio: discard_ratio,
-        expect,
-        abort,
-      }
+  let prop = map_total_result(prop, fn(res) {
+    {
+      ..res,
+      maybe_num_tests: max_success,
+      maybe_max_test_size: max_size,
+      maybe_max_shrinks: max_shrinks,
+      maybe_discarded_ratio: discard_ratio,
+      expect,
+      abort,
+    }
   })
   quick_check_with(Default::default(), prop)
 }

--- a/src/falsify/driver.mbt
+++ b/src/falsify/driver.mbt
@@ -111,7 +111,9 @@ pub fn[T, E] falsify(
             result_is_valid_shrink,
             ((e, run), shrunk),
           )
-          let explain = sf.e_fmap(@tuple.snd).limit_steps(Some(opt.max_shrinks))
+          let explain = sf
+            .e_fmap(fn(t) { t.1 })
+            .limit_steps(Some(opt.max_shrinks))
           let failure = { seed: acc.rng.clone(), run: explain }
           (acc.success, acc.total_discard, Some(failure))
         }

--- a/src/falsify/shrinking.mbt
+++ b/src/falsify/shrinking.mbt
@@ -16,11 +16,13 @@ pub fn[P, N] limit_steps(
   self : ShrinkExplain[P, N],
   n : Int?
 ) -> ShrinkExplain[P, N] {
-  fn go {
-    0, ShrinkTo(_) => ShrinkStopped
-    n, ShrinkTo(x, xs) => ShrinkTo(x, go(n - 1, xs))
-    _, ShrinkDone(xs) => ShrinkDone(xs)
-    _, ShrinkStopped => ShrinkStopped
+  fn go(n, hist) {
+    match (n, hist) {
+      (0, ShrinkTo(_)) => ShrinkStopped
+      (n, ShrinkTo(x, xs)) => ShrinkTo(x, go(n - 1, xs))
+      (_, ShrinkDone(xs)) => ShrinkDone(xs)
+      (_, ShrinkStopped) => ShrinkStopped
+    }
   }
 
   match n {
@@ -44,10 +46,10 @@ pub fn[P, N] shrink_history(self : ShrinkExplain[P, N]) -> Array[P] {
 
 ///|
 pub fn[P, N] shrink_outcome(self : ShrinkExplain[P, N]) -> (P, Iter[N]?) {
-  loop self.initial, self.history {
-    _, ShrinkTo(p, h) => continue p, h
-    p, ShrinkDone(ns) => (p, Some(ns))
-    p, ShrinkStopped => (p, None)
+  loop (self.initial, self.history) {
+    (_, ShrinkTo(p, h)) => continue (p, h)
+    (p, ShrinkDone(ns)) => (p, Some(ns))
+    (p, ShrinkStopped) => (p, None)
   }
 }
 
@@ -61,9 +63,11 @@ enum IsValidShrink[P, N] {
 
 ///|
 fn[A, B, C] either(f : (A) -> C, g : (B) -> C) -> (Result[A, B]) -> C {
-  fn {
-    Ok(x) => f(x)
-    Err(y) => g(y)
+  fn(res) {
+    match res {
+      Ok(x) => f(x)
+      Err(y) => g(y)
+    }
   }
 }
 
@@ -73,11 +77,17 @@ priv type Ret[T, E] ((Iter[T], Iter[E])) -> (Iter[T], Iter[E])
 ///|
 fn[T, E] partition_result(val : Iter[Result[T, E]]) -> (Iter[T], Iter[E]) {
   fn left(a : T) -> Ret[T, E] {
-    fn { (l, r) => (Iter::concat(Iter::singleton(a), l), r) }
+    fn(pair) {
+      let (l, r) = pair
+      (Iter::concat(Iter::singleton(a), l), r)
+    }
   }
 
   fn right(a : E) -> Ret[T, E] {
-    fn { (l, r) => (l, Iter::concat(Iter::singleton(a), r)) }
+    fn(pair) {
+      let (l, r) = pair
+      (l, Iter::concat(Iter::singleton(a), r))
+    }
   }
 
   let r = either(left, right)
@@ -113,15 +123,19 @@ pub fn[A, P, N] shrink_from(
 
 ///|
 pub fn[T] shrink_to_list(val : T, xs : Iter[T]) -> Gen[T] {
-  fn shrinker {
-    Shrunk(_) => Iter::empty()
-    NotShrunk(_) => abort("todo")
-    // @lazy.zip_with(fn(x, _y) { x }, @lazy.infinite_stream(0U, 1), xs)
+  fn shrinker(res) {
+    match res {
+      Shrunk(_) => Iter::empty()
+      NotShrunk(_) => abort("todo")
+      // @lazy.zip_with(fn(x, _y) { x }, @lazy.infinite_stream(0U, 1), xs)
+    }
   }
 
-  fn aux {
-    NotShrunk(_) => val
-    Shrunk(i) => xs.drop(i.reinterpret_as_int()).head().unwrap()
+  fn aux(res) {
+    match res {
+      NotShrunk(_) => val
+      Shrunk(i) => xs.drop(i.reinterpret_as_int()).head().unwrap()
+    }
   }
 
   prim_with(shrinker).fmap(aux)

--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -25,13 +25,13 @@ pub fn[T] singleton(val : T) -> Enumerate[T] {
 
 ///|
 pub fn[T] en_index(self : Enumerate[T], idx : BigInt) -> T {
-  loop self.parts, idx {
-    Nil, _ => abort("index out of bounds")
-    Cons(f, rest), i =>
+  loop (self.parts, idx) {
+    (Nil, _) => abort("index out of bounds")
+    (Cons(f, rest), i) =>
       if i < f.fCard {
         (f.fIndex)(i)
       } else {
-        continue rest.force(), i - f.fCard
+        continue (rest.force(), i - f.fCard)
       }
   }
 }
@@ -48,7 +48,7 @@ pub impl[T] Add for Enumerate[T] with op_add(self, other) {
 
 ///|
 pub fn[T, U] fmap(self : Enumerate[T], f : (T) -> U) -> Enumerate[U] {
-  { parts: self.parts.map(fn { x => fin_fmap(f, x) }) }
+  { parts: self.parts.map(fn(x) { fin_fmap(f, x) }) }
 }
 
 ///|
@@ -71,7 +71,10 @@ fn[T, U] prod_helper(
 
 ///|
 pub fn[T, U] app(f : Enumerate[(T) -> U], e : Enumerate[T]) -> Enumerate[U] {
-  product(f, e).fmap(fn { (ff, x) => ff(x) })
+  product(f, e).fmap(fn(p) {
+    let (ff, x) = p
+    ff(x)
+  })
 }
 
 ///|

--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -64,7 +64,13 @@ pub fn[T, U] fin_cart(f1 : Finite[T], f2 : Finite[U]) -> Finite[(T, U)] {
 
 ///|
 pub fn[M, N] fin_app(f : Finite[(M) -> N], e : Finite[M]) -> Finite[N] {
-  fin_fmap(fn { (g, x) => g(x) }, fin_cart(f, e))
+  fin_fmap(
+    fn(p) {
+      let (g, x) = p
+      g(x)
+    },
+    fin_cart(f, e),
+  )
 }
 
 ///|
@@ -104,9 +110,9 @@ pub fn[M] fin_mconcat(val : LazyList[Finite[M]]) -> Finite[M] {
 pub fn[T] to_array(self : Finite[T]) -> (BigInt, @immut/list.T[T]) {
   (
     self.fCard,
-    loop self.fCard, @immut/list.Nil {
-      0, acc => acc
-      n, acc => continue n - 1, Cons((self.fIndex)(n), acc)
+    loop (self.fCard, @immut/list.Nil) {
+      (0, acc) => acc
+      (n, acc) => continue (n - 1, Cons((self.fIndex)(n), acc))
     },
   )
 }

--- a/src/feat/utils.mbt
+++ b/src/feat/utils.mbt
@@ -23,16 +23,18 @@ fn[A, B] convolution(
 
 ///|
 fn[T] reversals(l : LazyList[T]) -> LazyList[LazyList[T]] {
-  fn go {
-    _, @lazy.Nil => @lazy.Nil
-    rev, Cons(x, xs) => {
-      let rev1 = @lazy.Cons(x, rev)
-      Cons(
-        rev1,
-        @lazy.LazyRef::from_thunk(fn() {
-          go(@lazy.LazyRef::from_value(rev1), xs.force())
-        }),
-      )
+  fn go(rev, lst) {
+    match lst {
+      @lazy.Nil => @lazy.Nil
+      Cons(x, xs) => {
+        let rev1 = @lazy.Cons(x, rev)
+        Cons(
+          rev1,
+          @lazy.LazyRef::from_thunk(fn() {
+            go(@lazy.LazyRef::from_value(rev1), xs.force())
+          }),
+        )
+      }
     }
   }
 

--- a/src/testing/gen.mbt
+++ b/src/testing/gen.mbt
@@ -45,7 +45,10 @@ impl @feat.Enumerable for SingleTree with enumerate() {
 
 ///|
 pub fn[A, B, C] pair_function(f : (A, B) -> C) -> ((A, B)) -> C {
-  fn { (x, y) => f(x, y) }
+  fn(t) {
+    let (x, y) = t
+    f(x, y)
+  }
 }
 
 ///|
@@ -62,7 +65,7 @@ priv struct Forest[T] {
 ///|
 impl[E : @feat.Enumerable] @feat.Enumerable for Forest[E] with enumerate() {
   @feat.pay(fn() {
-    @feat.Enumerable::enumerate().fmap(fn { forest => { forest, } })
+    @feat.Enumerable::enumerate().fmap(fn(forest) { { forest, } })
   })
 }
 
@@ -178,6 +181,6 @@ test "frequency" {
 ///|
 test "sized trivial" {
   let gen : @qc.Gen[Int] = @qc.sized(@qc.pure)
-  let arr = Array::makei(10, fn { i => gen.sample(size=i) })
+  let arr = Array::makei(10, fn(i) { gen.sample(size=i) })
   inspect(arr, content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")
 }

--- a/src/utils/common.mbt
+++ b/src/utils/common.mbt
@@ -52,11 +52,11 @@ pub fn[T] apply_while_list(
   f : (T) -> T,
   cond : (T) -> Bool
 ) -> @immut/list.T[T] {
-  loop x, @immut/list.T::Nil {
-    acc, lst => {
+  loop (x, @immut/list.T::Nil) {
+    (acc, lst) => {
       let next = f(acc)
       if cond(next) {
-        continue next, Cons(next, lst)
+        continue (next, Cons(next, lst))
       } else {
         break lst
       }
@@ -70,11 +70,11 @@ pub fn[T] apply_while_array(
   f : (T) -> T,
   cond : (T) -> Bool
 ) -> Array[T] {
-  loop x, [] {
-    acc, lst => {
+  loop (x, []) {
+    (acc, lst) => {
       let next = f(acc)
       if cond(next) {
-        continue next, [next, ..lst]
+        continue (next, [next, ..lst])
       } else {
         break lst
       }
@@ -87,12 +87,15 @@ pub fn[T] id(x : T) -> T = "%identity"
 
 ///|
 pub fn[T, U] const_(t : T) -> (U) -> T {
-  fn { _ => t }
+  fn(_) { t }
 }
 
 ///|
 pub fn[A, B, C] pair_function(f : (A, B) -> C) -> ((A, B)) -> C {
-  fn { (x, y) => f(x, y) }
+  fn(t) {
+    let (x, y) = t
+    f(x, y)
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
- update loops and anonymous functions to new syntax
- switch deprecated tuple accessor
- rework local functions to avoid matrix style

## Testing
- `moon check`
- `moon test`

------
https://chatgpt.com/codex/tasks/task_e_685b42b1c1208320bcc8c85ac99a996e