### PR TITLE
refactor: simplify state update logic in run_single_test and shrink_from functions

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -173,7 +173,12 @@ pub fn run_single_test(
   let rnd1 = self.random_state.split()
   let rnd2 = self.random_state
   let { val: res, branch: ts } = prop.inner().run(self.compute_size(), rnd1)
-  letrec next = fn(
+  fn update_state(st0 : State) {
+    self.random_state = rnd2
+    st0.update_state_from_res(res)
+  }
+
+  fn next(
     end_with : (State, Property) -> TestSuccess raise TestError,
     next_state : State,
     p : Property
@@ -184,10 +189,6 @@ pub fn run_single_test(
     } else {
       Err(next_state)
     }
-  }
-  and update_state = fn(st0 : State) {
-    self.random_state = rnd2
-    st0.update_state_from_res(res)
   }
 
   let stc = self.clone()

--- a/src/falsify/shrinking.mbt
+++ b/src/falsify/shrinking.mbt
@@ -104,19 +104,20 @@ pub fn[A, P, N] shrink_from(
   ps : (P, Iter[SampleTree])
 ) -> ShrinkExplain[P, N] {
   let (p, shrunk) = ps
-  letrec go = fn(shrunk : Iter[SampleTree]) -> ShrinkHistory[P, N] {
+  fn consider(ak) {
+    let (a, shrunk) = ak
+    match prop(a) {
+      Valid(p) => Ok((p, shrunk))
+      Invalid(n) => Err(n)
+    }
+  }
+
+  fn go(shrunk : Iter[SampleTree]) -> ShrinkHistory[P, N] {
     let candidates = shrunk.map(fn(x) { self.run_gen(x) |> consider })
     let res = partition_result(candidates)
     match res.0.head() {
       None => ShrinkDone(res.1)
       Some((p, shrunk)) => ShrinkTo(p, go(shrunk))
-    }
-  }
-  and consider = fn(ak) {
-    let (a, shrunk) = ak
-    match prop(a) {
-      Valid(p) => Ok((p, shrunk))
-      Invalid(n) => Err(n)
     }
   }
 


### PR DESCRIPTION
remove unneeded letrec

cc @CAIMEOX 