### PR TITLE
fix: enable unnecessary_annotation in all subpackages, clear all warnings

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -281,8 +281,8 @@ fn[A : @feat.Enumerable + Show, B : Testable] small_check_with_result(
       break st.complete_test(dummy)
     }
     match (parts, finite_opt) {
-      (@lazy.Nil, _) => break st.complete_test(dummy)
-      (@lazy.Cons(finite, rest), None) =>
+      (Nil, _) => break st.complete_test(dummy)
+      (Cons(finite, rest), None) =>
         if finite.fCard == 0 {
           continue rest.force(), None, 0, remaining, idx
         } else {
@@ -390,7 +390,7 @@ pub fn State::give_up(
       output="+++ \{self.counts()} Ok, gave up!",
     )
   } else {
-    raise TestError::GaveUp(
+    raise GaveUp(
       num_tests=self.num_success_tests,
       num_discarded=self.num_discarded_tests,
       coverage=self.collects,
@@ -464,7 +464,7 @@ pub fn State::find_failure(
   self.callback_post_final_failure(ce)
   match res.expect {
     Success | GaveUp =>
-      raise TestError::Fail(
+      raise Fail(
         error=res.error,
         replay_info=Replay::new(self.random_state, self.compute_size()),
         num_tests=self.num_success_tests + 1,
@@ -496,7 +496,7 @@ fn State::find_failure_no_shrink(
   self.callback_post_final_failure(res)
   match res.expect {
     Success | GaveUp =>
-      raise TestError::Fail(
+      raise Fail(
         error=res.error,
         replay_info=Replay::new(self.random_state, size),
         num_tests=self.num_success_tests + 1,

--- a/src/falsify/moon.pkg
+++ b/src/falsify/moon.pkg
@@ -5,3 +5,5 @@ import {
   "moonbitlang/core/sorted_set",
   "moonbitlang/core/quickcheck/splitmix" @splitmix,
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/falsify/selective.mbt
+++ b/src/falsify/selective.mbt
@@ -50,5 +50,5 @@ pub fn[T] Gen::ifS(self : Gen[Bool], t : Gen[T], e : Gen[T]) -> Gen[T] {
 
 ///|
 pub fn[A, B] Gen::apS(self : Gen[(A) -> B], x : Gen[A]) -> Gen[B] {
-  x.fmap(fn(y) { fn(g) { g(y) } }).select(self.fmap(fn(v) { Either::Left(v) }))
+  x.fmap(fn(y) { fn(g) { g(y) } }).select(self.fmap(fn(v) { Left(v) }))
 }

--- a/src/feat/README.mbt.md
+++ b/src/feat/README.mbt.md
@@ -273,7 +273,7 @@ test "product generates pairs, size = sum of component sizes" {
 
 ///|
 fn[T] wrap_finite(f : @feat.Finite[T]) -> @feat.Enumerate[T] {
-  { parts: @lazy.Cons(f, @lazy.LazyRef::from_value(@lazy.Nil)) }
+  { parts: Cons(f, @lazy.LazyRef::from_value(Nil)) }
 }
 ```
 

--- a/src/feat/enumerable.mbt
+++ b/src/feat/enumerable.mbt
@@ -13,10 +13,10 @@ pub impl Enumerable for Bool with enumerate() {
 ///|
 pub impl Enumerable for Int with enumerate() {
   letrec int_parts_from: (Int) -> @lazy.LazyList[Finite[Int]] = n => {
-    @lazy.Cons(
+    Cons(
       fin_pure(n),
       @lazy.LazyRef::from_thunk(fn() {
-        @lazy.Cons(
+        Cons(
           fin_pure(-n),
           @lazy.LazyRef::from_thunk(fn() { int_parts_from(n + 1) }),
         )
@@ -25,7 +25,7 @@ pub impl Enumerable for Int with enumerate() {
   }
 
   {
-    parts: @lazy.Cons(
+    parts: Cons(
       fin_pure(0),
       @lazy.LazyRef::from_thunk(fn() { int_parts_from(1) }),
     ),
@@ -35,10 +35,10 @@ pub impl Enumerable for Int with enumerate() {
 ///|
 pub impl Enumerable for Int64 with enumerate() {
   letrec int64_parts_from: (Int64) -> @lazy.LazyList[Finite[Int64]] = n => {
-    @lazy.Cons(
+    Cons(
       fin_pure(n),
       @lazy.LazyRef::from_thunk(fn() {
-        @lazy.Cons(
+        Cons(
           fin_pure(-n),
           @lazy.LazyRef::from_thunk(fn() { int64_parts_from(n + 1) }),
         )
@@ -47,7 +47,7 @@ pub impl Enumerable for Int64 with enumerate() {
   }
 
   {
-    parts: @lazy.Cons(
+    parts: Cons(
       fin_pure(0L),
       @lazy.LazyRef::from_thunk(fn() { int64_parts_from(1L) }),
     ),
@@ -69,9 +69,9 @@ pub impl Enumerable for Byte with enumerate() {
   let byte_card : BigInt = 256
   let byte_from_index = (i : BigInt) => Int::to_byte(i.to_int())
   {
-    parts: @lazy.Cons(
+    parts: Cons(
       { fCard: byte_card, fIndex: byte_from_index },
-      @lazy.LazyRef::from_value(@lazy.Nil),
+      @lazy.LazyRef::from_value(Nil),
     ),
   }
 }
@@ -85,9 +85,9 @@ pub impl Enumerable for Char with enumerate() {
     Int::unsafe_to_char(cp)
   }
   {
-    parts: @lazy.Cons(
+    parts: Cons(
       { fCard: char_card, fIndex: char_from_index },
-      @lazy.LazyRef::from_value(@lazy.Nil),
+      @lazy.LazyRef::from_value(Nil),
     ),
   }
 }
@@ -113,7 +113,7 @@ pub impl[A : Enumerable, B : Enumerable] Enumerable for (A, B) with enumerate() 
 
 ///|
 pub impl[E : Enumerable] Enumerable for E? with enumerate() {
-  pay(fn() { singleton(None) + E::enumerate().fmap(x => Option::Some(x)) })
+  pay(fn() { singleton(None) + E::enumerate().fmap(x => Some(x)) })
 }
 
 ///|

--- a/src/feat/moon.pkg
+++ b/src/feat/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/quickcheck/utils",
   "moonbitlang/core/list",
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/feat/utils.mbt
+++ b/src/feat/utils.mbt
@@ -21,10 +21,10 @@ fn[T] reversals(l : LazyList[T]) -> LazyList[LazyList[T]] {
     xs : LazyList[T],
   ) -> LazyList[LazyList[T]] {
     match (rev, xs) {
-      (_, @lazy.Nil) => @lazy.Nil
-      (rev, @lazy.Cons(x, xs)) => {
+      (_, Nil) => Nil
+      (rev, Cons(x, xs)) => {
         let rev1 = @lazy.Cons(x, rev)
-        @lazy.Cons(
+        Cons(
           rev1,
           @lazy.LazyRef::from_thunk(fn() {
             go(@lazy.LazyRef::from_value(rev1), xs.force())
@@ -34,5 +34,5 @@ fn[T] reversals(l : LazyList[T]) -> LazyList[LazyList[T]] {
     }
   }
 
-  go(@lazy.LazyRef::from_value(@lazy.Nil), l)
+  go(@lazy.LazyRef::from_value(Nil), l)
 }

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -59,7 +59,7 @@ pub fn[T] Gen::samples(
 fn[T] feat_helper(enumerate : @feat.Enumerate[T], size : Int) -> Gen[T] {
   for parts = enumerate.parts, bound = size {
     match parts {
-      @lazy.Nil => abort("uniform: empty enumeration")
+      Nil => abort("uniform: empty enumeration")
       _ => {
         let (incl, rest) = parts.split_at(bound)
         let fin = @feat.fin_mconcat(incl)

--- a/src/internal_benchmark/feat.mbt
+++ b/src/internal_benchmark/feat.mbt
@@ -8,7 +8,7 @@ priv enum Nat {
 impl @feat.Enumerable for Nat with enumerate() {
   @feat.pay(fn() {
     @feat.singleton(Zero) +
-    @feat.Enumerable::enumerate().fmap(fn(n) { Nat::Succ(n) })
+    @feat.Enumerable::enumerate().fmap(fn(n) { Succ(n) })
   })
 }
 

--- a/src/internal_benchmark/moon.pkg
+++ b/src/internal_benchmark/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/quickcheck/feat" @feat,
   "moonbitlang/core/bench" @bench,
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/internal_shrinking/moon.pkg
+++ b/src/internal_shrinking/moon.pkg
@@ -2,3 +2,5 @@ import {
   "moonbitlang/quickcheck/lazy",
   "moonbitlang/core/list",
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/internal_shrinking/shrink_tree.mbt
+++ b/src/internal_shrinking/shrink_tree.mbt
@@ -20,7 +20,7 @@ pub fn[T : Show] ShrinkTree::draw(
   fn shift(first : String, other : String, x : @list.List[String]) {
     @lazy.zip_lazy_normal(
       String::add,
-      @lazy.Cons(first, @lazy.LazyRef::from_value(@lazy.repeat(other))),
+      Cons(first, @lazy.LazyRef::from_value(@lazy.repeat(other))),
       x,
     )
   }

--- a/src/lazy/README.mbt.md
+++ b/src/lazy/README.mbt.md
@@ -234,14 +234,14 @@ test "unfold builds a countdown" {
   let seed = @lazy.from_list(@list.from_array([5]))
   let countdown = seed.unfold(cur => {
     match cur {
-      @lazy.Cons(n, _) =>
+      Cons(n, _) =>
         if n == 0 {
           None
         } else {
           let next = @lazy.from_list(@list.from_array([n - 1]))
           Some((n, next))
         }
-      @lazy.Nil => None
+      Nil => None
     }
   })
   inspect(countdown, content="[5, 4, 3, 2, 1]")

--- a/src/lazy/moon.pkg
+++ b/src/lazy/moon.pkg
@@ -3,3 +3,5 @@ import {
   "moonbitlang/core/quickcheck",
   "moonbitlang/core/sorted_set",
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -11,3 +11,5 @@ import {
   "moonbitlang/core/quickcheck/splitmix" @splitmix,
   "moonbitlang/core/sorted_map",
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/rose/moon.pkg
+++ b/src/rose/moon.pkg
@@ -1,1 +1,1 @@
-
+warnings = "+unnecessary_annotation"

--- a/src/testing/driver.mbt
+++ b/src/testing/driver.mbt
@@ -115,7 +115,7 @@ test "reject all" {
 
 ///|
 test "label" {
-  let ar : @qc.Arrow[List[Int], Bool] = @qc.Arrow(prop_rev)
+  let ar : @qc.Arrow[List[Int], Bool] = Arrow(prop_rev)
   inspect(
     @qc.quick_check_silence(
       @qc.Arrow(fn(x : List[Int]) {
@@ -266,7 +266,7 @@ impl Show for Nat with output(self, logger) {
 impl @feat.Enumerable for Nat with enumerate() {
   @feat.pay(fn() {
     @feat.singleton(Zero) +
-    @feat.Enumerable::enumerate().fmap(fn(n) { Nat::Succ(n) })
+    @feat.Enumerable::enumerate().fmap(fn(n) { Succ(n) })
   })
 }
 

--- a/src/testing/feat.mbt
+++ b/src/testing/feat.mbt
@@ -83,8 +83,8 @@ impl Show for SingleTree with output(self, logger) {
 impl @feat.Enumerable for SingleTree with enumerate() {
   @feat.consts(
     @list.from_array([
-      @feat.Enumerable::enumerate().fmap(x => SingleTree::Leaf(x)),
-      @feat.unary(pair_function((x, y) => SingleTree::Node(x, y))),
+      @feat.Enumerable::enumerate().fmap(x => Leaf(x)),
+      @feat.unary(pair_function((x, y) => Node(x, y))),
     ]),
   )
 }
@@ -138,8 +138,8 @@ impl[E : @feat.Enumerable] @feat.Enumerable for Forest[E] with enumerate() {
 ///|
 impl[E : @feat.Enumerable] @feat.Enumerable for Tree[E] with enumerate() {
   @feat.pay(fn() {
-    E::enumerate().fmap(x => Tree::Leaf(x)) +
-    @feat.Enumerable::enumerate().fmap(x => Tree::Branch(x))
+    E::enumerate().fmap(x => Leaf(x)) +
+    @feat.Enumerable::enumerate().fmap(x => Branch(x))
   })
 }
 

--- a/src/testing/moon.pkg
+++ b/src/testing/moon.pkg
@@ -5,3 +5,5 @@ import {
   "moonbitlang/core/quickcheck" @coreqc,
   "moonbitlang/core/sorted_set",
 }
+
+warnings = "+unnecessary_annotation"

--- a/src/utils/moon.pkg
+++ b/src/utils/moon.pkg
@@ -2,3 +2,5 @@ import {
   "moonbitlang/core/list",
   "moonbitlang/core/ref",
 }
+
+warnings = "+unnecessary_annotation"


### PR DESCRIPTION
## Summary

- Propagates `warnings = \"+unnecessary_annotation\"` from the root `src/moon.pkg` to every subpackage (`feat`, `lazy`, `rose`, `falsify`, `utils`, `testing`, `internal_benchmark`, `internal_shrinking`). The rest of the codebase is now held to the same standard the root already enforces.
- Clears the 35 warnings that surface once the flag is on.

## Nature of the fixes

All changes are mechanical prefix removals — the compiler resolves the constructor/variant from context, so the explicit qualifier is noise:

- `@lazy.Cons(...)` / `@lazy.Nil` → `Cons(...)` / `Nil` in match arms and constructors where the surrounding type is a `LazyList`.
- `TestError::Fail(...)` / `TestError::GaveUp(...)` → `Fail(...)` / `GaveUp(...)` at `raise` sites in `driver.mbt`.
- `Either::Left(v)` → `Left(v)` in `falsify/selective.mbt`.
- `Option::Some(x)` → `Some(x)` in `feat/enumerable.mbt`.
- `Nat::Succ(n)`, `SingleTree::Leaf(...)`, `Tree::Branch(...)`, `@qc.Arrow(...)` — similar tidy-ups in `internal_benchmark/` and `testing/`.

Two locations are inside `mbt check` blocks in the freshly-added READMEs (`src/feat/README.mbt.md`, `src/lazy/README.mbt.md`); those are fixed in place.

## Test plan

- [x] `moon check` — 0 warnings, 0 errors
- [x] `moon test` — 230 tests, 0 failures
- [x] `moon fmt` applied so CI's format check stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
