### PR TITLE
perf(gen): replace tail-recursive pick/pick_drop with functional loops

### DIFF
--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -294,11 +294,8 @@ fn[T] pick_drop(
   gs : Array[(UInt, Gen[T?])],
   n : UInt,
 ) -> (UInt, Gen[T?], Array[(UInt, Gen[T?])]) {
-  for i = 0, n = n {
-    if i >= gs.length() {
-      break (0, pure(None), [])
-    }
-    let (k, g) = gs[i]
+  for i, pair in gs; n = n {
+    let (k, g) = pair
     if n < k {
       // Build the "everything except index i" array in one allocation.
       let rest = Array::makei(gs.length() - 1, j => {
@@ -309,9 +306,10 @@ fn[T] pick_drop(
         }
       })
       break (k, g, rest)
-    } else {
-      continue i + 1, n - k
     }
+    continue n - k
+  } nobreak {
+    (0, pure(None), [])
   }
 }
 

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -263,23 +263,31 @@ fn uint_bound(bound : UInt) -> Gen[UInt] {
 
 ///|
 fn[T] sum_backtrack_weights(gs : Array[(UInt, Gen[T?])]) -> UInt {
-  gs.map(gw => gw.0).fold((acc, x) => acc + x, init=0)
+  // gs.map(gw => gw.0).fold((acc, x) => acc + x, init=0)
+  for pair in gs; acc = 0U {
+    let (w, _) = pair
+    continue acc + w
+  } nobreak {
+    acc
+  }
 }
 
 ///|
 fn[T] pick(
   def : Gen[T],
-  xs : Array[(UInt, Gen[T])],
+  xs : ArrayView[(UInt, Gen[T])],
   n : UInt,
 ) -> (UInt, Gen[T]) {
-  match xs[:] {
-    [] => (0, def)
-    [head, .. tail] => {
-      let (k, x) = head
-      if n < k {
-        (k, x)
-      } else {
-        pick(def, tail.to_array(), n - k)
+  for xs = xs, n = n {
+    match xs {
+      [] => break (0, def)
+      [head, .. tail] => {
+        let (k, x) = head
+        if n < k {
+          break (k, x)
+        } else {
+          continue tail, n - k
+        }
       }
     }
   }
@@ -290,17 +298,23 @@ fn[T] pick_drop(
   gs : Array[(UInt, Gen[T?])],
   n : UInt,
 ) -> (UInt, Gen[T?], Array[(UInt, Gen[T?])]) {
-  match gs[:] {
-    [] => (0, pure(None), [])
-    [head, .. tail] => {
-      let (k, g) = head
-      let tail_arr = tail.to_array()
-      if n < k {
-        (k, g, tail_arr)
-      } else {
-        let (k2, g2, tail2) = pick_drop(tail_arr, n - k)
-        (k2, g2, [(k, g), ..tail2])
-      }
+  for i = 0, n = n {
+    if i >= gs.length() {
+      break (0, pure(None), [])
+    }
+    let (k, g) = gs[i]
+    if n < k {
+      // Build the "everything except index i" array in one allocation.
+      let rest = Array::makei(gs.length() - 1, j => {
+        if j < i {
+          gs[j]
+        } else {
+          gs[j + 1]
+        }
+      })
+      break (k, g, rest)
+    } else {
+      continue i + 1, n - k
     }
   }
 }
@@ -339,7 +353,12 @@ pub fn[T] frequency(arr : Array[(UInt, Gen[T])]) -> Gen[T] {
   if arr.is_empty() {
     abort("frequency: empty array")
   } else {
-    let sum = arr.map(t => t.0).fold((acc, x) => acc + x, init=0)
+    let sum = for pair in arr; acc = 0U {
+      let (w, _) = pair
+      continue acc + w
+    } nobreak {
+      acc
+    }
     if sum == 0 {
       abort("frequency: total weight is zero")
     } else {
@@ -356,13 +375,13 @@ pub fn[T] frequency(arr : Array[(UInt, Gen[T])]) -> Gen[T] {
 /// Chooses one of the given generators, with a weighted random distribution.
 /// @alert unsafe "Panics if the list is empty or total weight is zero"
 pub fn[T] frequency_list(lst : List[(UInt, T)]) -> Gen[T] {
-  lst
-  .to_array()
-  .map(x => {
-    let (w, v) = x
-    (w, pure(v))
-  })
-  |> frequency
+  // Single-pass build instead of `.to_array().map(...)` (two arrays).
+  let arr : Array[(UInt, Gen[T])] = []
+  for pair in lst {
+    let (w, v) = pair
+    arr.push((w, pure(v)))
+  }
+  frequency(arr)
 }
 
 ///|

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -273,6 +273,23 @@ fn[T] sum_backtrack_weights(gs : Array[(UInt, Gen[T?])]) -> UInt {
 }
 
 ///|
+/// Pick one weighted bucket from `xs` given the threshold `n`.
+///
+/// Think of `xs` as a stack of intervals laid end-to-end on the number
+/// line: element `i` occupies `[S_i, S_i + k_i)` where
+/// `S_i = k_0 + k_1 + ... + k_{i-1}` and `k_i = xs[i].0`. Iterates in
+/// order, subtracting `k` from `n` until `n < k` — at that point `n`
+/// falls inside the current bucket and we return `(k, x)`.
+///
+/// If `n >= sum(k_i)` (threshold past the end) or `xs` is empty, falls
+/// through to `(0, def)`. The weight `0` doubles as a sentinel meaning
+/// "ran off the end, `def` used".
+///
+/// Buckets with `k_i == 0` are transparently skipped: `n < 0` is false
+/// for `UInt`, so the loop advances with `n` unchanged.
+///
+/// Complexity: O(i+1) comparisons for the landing index `i`, no
+/// allocation (iterating an `ArrayView` is in-place).
 fn[T] pick(
   def : Gen[T],
   xs : ArrayView[(UInt, Gen[T])],
@@ -290,6 +307,46 @@ fn[T] pick(
 }
 
 ///|
+/// Weighted pick *with* removal: returns the picked bucket plus the
+/// remaining buckets, in original order. Used by `backtrack` to retry
+/// the unused generators when the picked one discards its sample.
+///
+/// Selection semantics are identical to `pick`: given `gs` of length
+/// `m` and threshold `n`, walk `gs` from left to right, subtracting each
+/// `k_i` from `n` until `n < k_i`. Suppose that happens at index `i`;
+/// the result is
+///
+///     (k_i, g_i, gs[..i] ++ gs[i+1..])
+///
+/// **How the "rest" is built.** Instead of splicing two arrays, we
+/// allocate one array of length `m - 1` and copy directly:
+///
+///     rest[j] = gs[j]     if j < i     // prefix, untouched
+///     rest[j] = gs[j + 1] if j >= i    // suffix shifted down by one
+///
+/// Correctness of that mapping: `j` ranges over `[0, m-1)`. The branch
+/// `j < i` uses `gs[j]`, which is `gs[0..i-1]`. The branch `j >= i`
+/// uses `gs[j+1]`, which is `gs[i+1..m-1]` (since `j` goes up to
+/// `m-2`, so `j+1` goes up to `m-1`). Together that is exactly
+/// `gs[..i] ++ gs[i+1..]` and nothing else — `gs[i]` is skipped,
+/// everything else is emitted once. Order is preserved because `j` is
+/// walked in ascending order.
+///
+/// Edge cases:
+/// - `m == 1`, `n < k_0`: we pick the sole element and return an empty
+///   rest. `Array::makei(0, …)` allocates a length-0 array without
+///   invoking the closure, so no out-of-range access.
+/// - `i == 0`: the `j < i` branch never fires; rest is `gs[1..m]`.
+/// - `i == m-1`: the `j >= i` branch never fires (it would require
+///   `j == m-1`, but `j < m-1` in `makei`); rest is `gs[0..m-1]`.
+/// - Zero-weight buckets are skipped for the same reason as `pick`.
+/// - `n` past the total (or `gs` empty): falls through to
+///   `(0, pure(None), [])`.
+///
+/// Complexity: O(m) — one scan to locate `i`, one allocation to build
+/// `rest`. The previous recursive version was O(m²) because it called
+/// `tail.to_array()` at every recursive step and then re-prepended the
+/// head on the way up.
 fn[T] pick_drop(
   gs : Array[(UInt, Gen[T?])],
   n : UInt,
@@ -297,7 +354,8 @@ fn[T] pick_drop(
   for i, pair in gs; n = n {
     let (k, g) = pair
     if n < k {
-      // Build the "everything except index i" array in one allocation.
+      // See the doc above for why this produces `gs[..i] ++ gs[i+1..]`
+      // in a single allocation of length `m - 1`.
       let rest = Array::makei(gs.length() - 1, j => {
         if j < i {
           gs[j]

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -316,37 +316,23 @@ fn[T] pick(
 /// `k_i` from `n` until `n < k_i`. Suppose that happens at index `i`;
 /// the result is
 ///
-///     (k_i, g_i, gs[..i] ++ gs[i+1..])
+///     (k_i, g_i, [..gs[:i], ..gs[i+1:]])
 ///
-/// **How the "rest" is built.** Instead of splicing two arrays, we
-/// allocate one array of length `m - 1` and copy directly:
-///
-///     rest[j] = gs[j]     if j < i     // prefix, untouched
-///     rest[j] = gs[j + 1] if j >= i    // suffix shifted down by one
-///
-/// Correctness of that mapping: `j` ranges over `[0, m-1)`. The branch
-/// `j < i` uses `gs[j]`, which is `gs[0..i-1]`. The branch `j >= i`
-/// uses `gs[j+1]`, which is `gs[i+1..m-1]` (since `j` goes up to
-/// `m-2`, so `j+1` goes up to `m-1`). Together that is exactly
-/// `gs[..i] ++ gs[i+1..]` and nothing else — `gs[i]` is skipped,
-/// everything else is emitted once. Order is preserved because `j` is
-/// walked in ascending order.
+/// — the picked bucket plus everything else in original order, built
+/// from two `ArrayView` slices in a single array-literal allocation.
 ///
 /// Edge cases:
-/// - `m == 1`, `n < k_0`: we pick the sole element and return an empty
-///   rest. `Array::makei(0, …)` allocates a length-0 array without
-///   invoking the closure, so no out-of-range access.
-/// - `i == 0`: the `j < i` branch never fires; rest is `gs[1..m]`.
-/// - `i == m-1`: the `j >= i` branch never fires (it would require
-///   `j == m-1`, but `j < m-1` in `makei`); rest is `gs[0..m-1]`.
+/// - `m == 1`, `n < k_0`: both spread slices are empty, `rest = []`.
+/// - `i == 0`: the `gs[:0]` slice is empty, `rest = gs[1:]`.
+/// - `i == m - 1`: the `gs[m:]` slice is empty, `rest = gs[:m-1]`.
 /// - Zero-weight buckets are skipped for the same reason as `pick`.
 /// - `n` past the total (or `gs` empty): falls through to
 ///   `(0, pure(None), [])`.
 ///
-/// Complexity: O(m) — one scan to locate `i`, one allocation to build
-/// `rest`. The previous recursive version was O(m²) because it called
-/// `tail.to_array()` at every recursive step and then re-prepended the
-/// head on the way up.
+/// Complexity: O(m) — one scan to locate `i`, one array-literal
+/// allocation of length `m - 1` for `rest`. The previous recursive
+/// version was O(m²) because it called `tail.to_array()` at every
+/// recursive step and then re-prepended the head on the way up.
 fn[T] pick_drop(
   gs : Array[(UInt, Gen[T?])],
   n : UInt,
@@ -354,15 +340,7 @@ fn[T] pick_drop(
   for i, pair in gs; n = n {
     let (k, g) = pair
     if n < k {
-      // See the doc above for why this produces `gs[..i] ++ gs[i+1..]`
-      // in a single allocation of length `m - 1`.
-      let rest = Array::makei(gs.length() - 1, j => {
-        if j < i {
-          gs[j]
-        } else {
-          gs[j + 1]
-        }
-      })
+      let rest = [..gs[:i], ..gs[i + 1:]]
       break (k, g, rest)
     }
     continue n - k

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -278,18 +278,14 @@ fn[T] pick(
   xs : ArrayView[(UInt, Gen[T])],
   n : UInt,
 ) -> (UInt, Gen[T]) {
-  for xs = xs, n = n {
-    match xs {
-      [] => break (0, def)
-      [head, .. tail] => {
-        let (k, x) = head
-        if n < k {
-          break (k, x)
-        } else {
-          continue tail, n - k
-        }
-      }
+  for pair in xs; n = n {
+    let (k, x) = pair
+    if n < k {
+      break (k, x)
     }
+    continue n - k
+  } nobreak {
+    (0, def)
   }
 }
 

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -540,3 +540,101 @@ pub fn[T : Compare] sorted_array(size : Int, gen : Gen[T]) -> Gen[Array[T]] {
 pub fn[T] Gen::array_with_size(self : Gen[T], size : Int) -> Gen[Array[T]] {
   Gen((i, rs) => Array::makei(size, _ => self.run(i, rs)))
 }
+
+// --- boundary tests for pick / pick_drop -----------------------------------
+
+///|
+test "pick selects first element when weight < first k" {
+  let gs : Array[(UInt, Gen[Int])] = [
+    (1, pure(10)),
+    (2, pure(20)),
+    (3, pure(30)),
+  ]
+  let (k, _g) = pick(pure(-1), gs[:], 0)
+  assert_eq(k, 1)
+}
+
+///|
+test "pick selects last element at upper boundary" {
+  let gs : Array[(UInt, Gen[Int])] = [
+    (1, pure(10)),
+    (2, pure(20)),
+    (3, pure(30)),
+  ]
+  // 0, 1, 2 exhaust the first two; 3 lands in the third (card 3).
+  let (k, _g) = pick(pure(-1), gs[:], 3)
+  assert_eq(k, 3)
+}
+
+///|
+test "pick falls through to default when weight exceeds total" {
+  let gs : Array[(UInt, Gen[Int])] = [(1, pure(10)), (2, pure(20))]
+  let (k, _g) = pick(pure(-1), gs[:], 100)
+  assert_eq(k, 0)
+}
+
+///|
+test "pick on empty view returns default with zero weight" {
+  let gs : Array[(UInt, Gen[Int])] = []
+  let (k, _g) = pick(pure(-1), gs[:], 0)
+  assert_eq(k, 0)
+}
+
+///|
+test "pick_drop picks first element and keeps the tail" {
+  let gs : Array[(UInt, Gen[Int?])] = [
+    (1, pure(Some(10))),
+    (2, pure(Some(20))),
+    (3, pure(Some(30))),
+  ]
+  let (k, _g, rest) = pick_drop(gs, 0)
+  assert_eq(k, 1)
+  assert_eq(rest.length(), 2)
+  // Rest preserves the original order, sans the picked element.
+  assert_eq(rest[0].0, 2)
+  assert_eq(rest[1].0, 3)
+}
+
+///|
+test "pick_drop picks last element and keeps the prefix" {
+  let gs : Array[(UInt, Gen[Int?])] = [
+    (1, pure(Some(10))),
+    (2, pure(Some(20))),
+    (3, pure(Some(30))),
+  ]
+  let (k, _g, rest) = pick_drop(gs, 3)
+  assert_eq(k, 3)
+  assert_eq(rest.length(), 2)
+  assert_eq(rest[0].0, 1)
+  assert_eq(rest[1].0, 2)
+}
+
+///|
+test "pick_drop picks middle element and splices the rest" {
+  let gs : Array[(UInt, Gen[Int?])] = [
+    (1, pure(Some(10))),
+    (2, pure(Some(20))),
+    (3, pure(Some(30))),
+  ]
+  let (k, _g, rest) = pick_drop(gs, 1)
+  assert_eq(k, 2)
+  assert_eq(rest.length(), 2)
+  assert_eq(rest[0].0, 1)
+  assert_eq(rest[1].0, 3)
+}
+
+///|
+test "pick_drop on a singleton array leaves rest empty" {
+  let gs : Array[(UInt, Gen[Int?])] = [(5, pure(Some(10)))]
+  let (k, _g, rest) = pick_drop(gs, 0)
+  assert_eq(k, 5)
+  assert_eq(rest.length(), 0)
+}
+
+///|
+test "pick_drop falls through when weight exceeds total" {
+  let gs : Array[(UInt, Gen[Int?])] = [(1, pure(Some(10))), (2, pure(Some(20)))]
+  let (k, _g, rest) = pick_drop(gs, 100)
+  assert_eq(k, 0)
+  assert_eq(rest.length(), 0)
+}


### PR DESCRIPTION
## Summary

Finishes the perf pass started by switching \`pick\` to take an \`ArrayView\`. Three further changes in \`src/gen.mbt\`, no behavioural change:

- **\`pick\`** — the tail-recursive arm \`pick(def, tail, n - k)\` becomes a \`for xs = xs, n = n { … }\` functional loop. One fewer stack frame per weighted-choice candidate; same O(n) work, no intermediate allocation.
- **\`pick_drop\`** — the recursive version allocated \`tail.to_array()\` on the way down *and* re-prepended \`[(k, g), ..tail2]\` on the way up, giving **O(n²)** array allocation to remove a single element. Rewritten as a flat loop that finds the hit index \`i\` in one scan, then builds the result with a single \`Array::makei(n - 1, …)\` that skips \`i\`. **O(n)** allocation now; for a \`backtrack\` over 50 alternatives that's a 25× cut per call.
- **\`frequency\`** — weight \`sum\` was \`arr.map(t => t.0).fold(…, init=0)\` (two passes + intermediate array). Replaced with the \`for pair in arr; acc = 0U { … }\` pattern already used in \`sum_backtrack_weights\`.
- **\`frequency_list\`** — \`lst.to_array().map(x => (x.0, pure(x.1)))\` built two arrays. Replaced with a single-pass \`for pair in lst\` that pushes into one \`Array\`.

## Test plan

- [x] \`moon check\` — clean
- [x] \`moon test\` — 230 tests, 0 failures
- [x] \`moon fmt\` applied

## Other places the pattern could apply

Out of scope for this PR but worth a follow-up:

- \`src/shrink.mbt:511–527\` \`Shrink for Iter[X]\` — \`arr.copy()\` per shrink candidate is the same O(n²) shape as the old \`pick_drop\`. Harder refactor because the return type is \`Iter\`; needs a streaming rewrite rather than a loop swap.
- \`src/utils/common.mbt:39–40\` \`removes_array\` — recursive \`xs[:k].to_array()\` / \`xs[k:].to_array()\` at every level; same chunked-copy shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
