### PR TITLE
feat(rose): add Rose::iter for depth-first traversal

### DIFF
--- a/src/rose/README.mbt.md
+++ b/src/rose/README.mbt.md
@@ -128,6 +128,7 @@ instance needed.
 | `Rose::bind(r, f)` | `Rose[T] -> (T -> Rose[U]) -> Rose[U]` | Dependent substitution |
 | `Rose::join(r)` | `Rose[Rose[T]] -> Rose[T]` | Flatten two levels |
 | `Rose::apply(r, f)` | `Rose[T] -> ((T, Iter[Rose[T]]) -> Rose[T]) -> Rose[T]` | Inspect node + its branch |
+| `Rose::iter(r)` | `Rose[T] -> Iter[T]` | Lazy depth-first walk; enables `for x in r { ... }` |
 
 ### `fmap`
 
@@ -208,6 +209,41 @@ test "apply rewrites a single node" {
   assert_eq(collapsed.branch.count(), 0)
 }
 ```
+
+### `iter` — depth-first walk and `for x in rose { ... }`
+
+`Rose::iter` produces a lazy `Iter[T]` over every value in the tree, root
+first, then each branch depth-first. Because MoonBit's `for x in <expr>`
+loop calls `<expr>.iter()`, you can use `Rose` directly with the loop sugar.
+
+```mbt check
+///|
+test "iter visits root then branches in DFS order" {
+  let tree = @rose.new(
+    1,
+    [
+      @rose.new(2, [@rose.pure(3), @rose.pure(4)].iter()),
+      @rose.new(5, [@rose.pure(6)].iter()),
+    ].iter(),
+  )
+  assert_eq(tree.iter().collect(), [1, 2, 3, 4, 5, 6])
+}
+
+///|
+test "for .. in walks every value" {
+  let tree = @rose.new(10, [@rose.pure(20), @rose.pure(30)].iter())
+  let seen : Array[Int] = []
+  for x in tree {
+    seen.push(x)
+  }
+  assert_eq(seen, [10, 20, 30])
+}
+```
+
+The traversal is lazy: only as many sub-trees as you actually consume
+get forced. Like every `Iter` in MoonBit it is single-shot, so a second
+walk over the same `Rose` will only see whatever branches were not yet
+consumed by an earlier walk.
 
 ---
 

--- a/src/rose/pkg.generated.mbti
+++ b/src/rose/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub(all) struct Rose[T] {
 pub fn[T] Rose::apply(Self[T], (T, Iter[Self[T]]) -> Self[T]) -> Self[T]
 pub fn[T, U] Rose::bind(Self[T], (T) -> Self[U]) -> Self[U]
 pub fn[T, U] Rose::fmap(Self[T], (T) -> U) -> Self[U]
+pub fn[T] Rose::iter(Self[T]) -> Iter[T]
 pub fn[T] Rose::join(Self[Self[T]]) -> Self[T]
 
 // Type aliases

--- a/src/rose/rose.mbt
+++ b/src/rose/rose.mbt
@@ -40,3 +40,52 @@ pub fn[T] Rose::apply(
 ) -> Rose[T] {
   f(self.val, self.branch)
 }
+
+///|
+/// Pre-order traversal: yields the root value, then the values of every
+/// branch depth-first. Enables `for x in rose { ... }` and any other
+/// `Iter`-shaped consumer.
+///
+/// The traversal is lazy: only as many sub-trees as you actually walk
+/// are forced. Note that — like every `Iter` in MoonBit — the result
+/// is single-shot; iterating the same `Rose` twice will only visit the
+/// elements that were not yet consumed by an earlier walk.
+pub fn[T] Rose::iter(self : Rose[T]) -> Iter[T] {
+  Iter::singleton(self.val) + self.branch.flat_map(child => child.iter())
+}
+
+///|
+test "iter walks root then branches in depth-first order" {
+  // A small handcrafted tree:
+  //
+  //        1
+  //       / \
+  //      2   5
+  //     / \   \
+  //    3   4   6
+  let leaf = pure
+  let tree = Rose::{
+    val: 1,
+    branch: [
+      { val: 2, branch: [leaf(3), leaf(4)].iter() },
+      { val: 5, branch: [leaf(6)].iter() },
+    ].iter(),
+  }
+  let collected = tree.iter().collect()
+  assert_eq(collected, [1, 2, 3, 4, 5, 6])
+}
+
+///|
+test "iter on a leaf yields only the root" {
+  assert_eq(pure(42).iter().collect(), [42])
+}
+
+///|
+test "for .. in sugar walks every value" {
+  let tree = Rose::{ val: 10, branch: [pure(20), pure(30)].iter() }
+  let acc = []
+  for x in tree {
+    acc.push(x)
+  }
+  assert_eq(acc, [10, 20, 30])
+}

--- a/src/rose/rose.mbt
+++ b/src/rose/rose.mbt
@@ -89,3 +89,51 @@ test "for .. in sugar walks every value" {
   }
   assert_eq(acc, [10, 20, 30])
 }
+
+///|
+/// Sibling branches are an infinite stream. `iter().take(n)` must
+/// terminate — a naive eager implementation would try to build an
+/// unbounded prefix before yielding anything.
+test "iter is lazy over an infinite-width tree" {
+  let infinite_siblings = Iter::repeat(pure(7))
+  let tree = Rose::{ val: 0, branch: infinite_siblings }
+  assert_eq(tree.iter().take(5).collect(), [0, 7, 7, 7, 7])
+}
+
+///|
+/// Depth is unbounded: spine(n) has exactly one child, spine(n+1).
+/// The `branch` field is a lazy `Iter::new(...)` so the recursive call
+/// is only forced when the outer iterator pulls a value. If
+/// `Rose::iter` were not lazy, building spine(0) or calling .iter() on
+/// it would non-terminate.
+test "iter is lazy over an infinite-depth spine" {
+  fn spine(n : Int) -> Rose[Int] {
+    let mut pulled = false
+    let branch : Iter[Rose[Int]] = Iter::new(() => {
+      if pulled {
+        None
+      } else {
+        pulled = true
+        Some(spine(n + 1))
+      }
+    })
+    { val: n, branch }
+  }
+
+  assert_eq(spine(0).iter().take(6).collect(), [0, 1, 2, 3, 4, 5])
+}
+
+///|
+/// Early `break` in a `for .. in` loop must also be lazy: we should
+/// never touch the sub-trees past the break point.
+test "for .. in with early break visits only the prefix" {
+  let infinite = Rose::{ val: 0, branch: Iter::repeat(pure(1)) }
+  let acc = []
+  for x in infinite {
+    if acc.length() == 3 {
+      break
+    }
+    acc.push(x)
+  }
+  assert_eq(acc, [0, 1, 1])
+}


### PR DESCRIPTION
## Summary

Adds a single method, \`Rose::iter(self) -> Iter[T]\`, that yields the root value followed by a depth-first walk of every branch. Because MoonBit's \`for x in <expr>\` loop desugars to \`<expr>.iter()\`, this makes \`for x in rose { ... }\` work out of the box.

```moonbit
let tree = @rose.new(
  1,
  [
    @rose.new(2, [@rose.pure(3), @rose.pure(4)].iter()),
    @rose.new(5, [@rose.pure(6)].iter()),
  ].iter(),
)

assert_eq(tree.iter().collect(), [1, 2, 3, 4, 5, 6])

for x in tree { /* visits 1, 2, 3, 4, 5, 6 */ }
```

The traversal is lazy: only the sub-trees you actually consume are forced. Like every \`Iter\` in MoonBit it is single-shot.

## Test plan

- [x] 3 new whitebox tests in \`rose.mbt\`: hand-built tree, leaf, \`for x in rose\` sugar
- [x] 2 new doc-tests in \`README.mbt.md\` (DFS order + \`for x in tree\`)
- [x] \`moon check\` clean
- [x] \`moon test\` — 244 / 244
- [x] \`moon fmt\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/88" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
