### PR TITLE
refactor: consolidate public types into src/types.mbt

### DIFF
--- a/src/axiom.mbt
+++ b/src/axiom.mbt
@@ -1,8 +1,5 @@
-///|
-pub(all) struct Equivalence[T] {
-  lhs : T
-  rhs : T
-}
+// `Equivalence[T]` is declared in `types.mbt`. Methods and the `Show`
+// impl for it live here.
 
 ///|
 pub impl[T : Show] Show for Equivalence[T] with output(self, logger) {

--- a/src/result.mbt
+++ b/src/result.mbt
@@ -1,16 +1,5 @@
-///|
-pub(all) enum Outcome[T] {
-  Success
-  GaveUp
-  Fail(T) // Counterexample
-}
-
-///|
-pub(all) enum Expected {
-  Fail
-  Success
-  GaveUp
-}
+// `Outcome[T]`, `Expected`, and `Replay` are declared in `types.mbt`.
+// Their Show impl and constructor helpers live here.
 
 ///|
 pub impl[T] Show for Outcome[T] with output(self, logger) {
@@ -19,12 +8,6 @@ pub impl[T] Show for Outcome[T] with output(self, logger) {
     Success => logger.write_string("OK")
     GaveUp => logger.write_string("GAVE UP")
   }
-}
-
-///|
-pub(all) struct Replay {
-  rand_state : RandomState
-  size : Int
 }
 
 ///|

--- a/src/testable.mbt
+++ b/src/testable.mbt
@@ -3,14 +3,8 @@ priv suberror InternalError {
   InternalError(String)
 }
 
-///|
-pub(all) struct Arrow[A, B]((A) -> B)
-
-///|
-pub(all) struct ArrowError[A, B]((A) -> B raise)
-
-///|
-pub(all) struct ArrowAsync[A, B](async (A) -> B)
+// `Arrow`, `ArrowError`, and `ArrowAsync` are declared in `types.mbt`.
+// The `Testable` impls for them live further down in this file.
 
 ///|
 type RoseRes = Rose[SingleResult]

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -1,0 +1,165 @@
+// -----------------------------------------------------------------------
+// Public type surface for `moonbitlang/quickcheck`.
+//
+// This file consolidates every public, user-facing type declared by the
+// root package so that an author exploring the library can find and
+// understand the core data structures in one place. Methods, traits, and
+// implementation-private helpers stay in the file that owns the
+// behaviour — see the referenced files in each docstring.
+//
+// The types fall into three conceptual groups:
+//
+//   1. Property outcomes:     Outcome[T], Expected
+//   2. Replay & auditing:     Replay
+//   3. Testable plumbing:     Arrow[A, B], ArrowError, ArrowAsync,
+//                             Equivalence[T]
+//
+// `Gen[T]` deliberately stays in `gen.mbt` — its struct body carries
+// the primary-constructor declaration plus every combinator method, so
+// splitting it would cost more than it saves.
+// -----------------------------------------------------------------------
+
+// ========================================================================
+//  Property outcomes
+// ========================================================================
+
+///|
+/// The outcome the driver reports for a single `quick_check` run.
+///
+/// The classical QuickCheck trichotomy:
+///
+/// - `Success`: every test passed; no counterexample was found within
+///   the configured budget.
+/// - `GaveUp`: too many inputs were discarded (via preconditions or
+///   `@qc.filter`) before we could run the requested number of tests.
+/// - `Fail(t)`: at least one generated input falsified the property.
+///   `t` carries the already-shrunk counterexample in whatever shape
+///   the driver chose — typically a pretty-printable record of the
+///   failing case, the seed, and the shrink trail.
+///
+/// The `Show` implementation (defined in `result.mbt`) renders `OK`,
+/// `GAVE UP`, or `FAIL`, irrespective of the payload of `Fail`. Users
+/// who need the payload should pattern-match on the `Outcome`
+/// directly.
+pub(all) enum Outcome[T] {
+  Success
+  GaveUp
+  Fail(T) // Counterexample
+}
+
+///|
+/// What the *author* of a property *expects* to happen. This is the
+/// knob behind `quick_check_fn(..., expect=Fail)` and friends: if the
+/// driver's actual `Outcome` matches `Expected`, the check is
+/// considered a pass even when the property raises.
+///
+/// Use cases:
+///
+/// - `Success` (the default) — property must hold on every generated
+///   input.
+/// - `Fail` — the property *should* fail; useful when you want to
+///   demonstrate a known bug or lock in a regression check. The test
+///   fails if the driver *can't* find a counterexample.
+/// - `GaveUp` — the property is expected to discard too many cases.
+///   Rarely useful in isolation; handy for testing the driver itself.
+pub(all) enum Expected {
+  Fail
+  Success
+  GaveUp
+}
+
+// ========================================================================
+//  Replay & auditing
+// ========================================================================
+
+///|
+/// A snapshot of the RNG state and size parameter sufficient to rerun
+/// a property on the exact same input sequence.
+///
+/// Every failing `Outcome::Fail` in the driver carries a `Replay`
+/// inside its counterexample record — copy it into a test, pass it
+/// back via the driver's replay hook, and you will deterministically
+/// reproduce the failure on any machine. This is how the project's
+/// test suite pins previously-found counterexamples.
+///
+/// Fields:
+/// - `rand_state`: SplitMix seed captured just before the offending
+///   sample was drawn.
+/// - `size`: the size parameter the property was running at (the same
+///   value threaded through `sized` / `scale`).
+///
+/// Constructor: `Replay::new(rand_state, size)` (see `result.mbt`).
+pub(all) struct Replay {
+  rand_state : RandomState
+  size : Int
+}
+
+// ========================================================================
+//  Testable plumbing
+// ========================================================================
+
+///|
+/// `Arrow[A, B]` is a newtype wrapper around a pure, total function
+/// `(A) -> B`. Wrapping is what lets us write
+///
+///     pub impl[P : Testable, A : Arbitrary + Shrink + Show] Testable for Arrow[A, P]
+///
+/// — MoonBit does not let us implement a trait *directly* on the bare
+/// function type `(A) -> B`, so `Arrow` is the obligatory detour.
+///
+/// For the user this shows up as `@qc.Arrow(prop)` at the driver
+/// boundary:
+///
+///     @qc.quick_check(@qc.Arrow(fn(x : Int) -> Bool { x == x }))
+///
+/// Most users never see `Arrow` directly because `quick_check_fn`
+/// wraps the function for them. Reach for the explicit form only when
+/// you need to hand a `Testable`-wrapped property to a combinator that
+/// takes `Testable` values (e.g. `classify`, `label`).
+///
+/// See also: `ArrowError` (for properties that may `raise`) and
+/// `ArrowAsync` (for properties that are `async`).
+pub(all) struct Arrow[A, B]((A) -> B)
+
+///|
+/// Same role as `Arrow`, but the wrapped function may `raise` an error.
+/// Use this when your property calls into code that throws and you
+/// want the driver to treat a raised exception as a test failure with
+/// the captured error as the counterexample's `reason`.
+///
+/// Under the hood it's identical to `Arrow` plus a `raise` clause.
+pub(all) struct ArrowError[A, B]((A) -> B raise)
+
+///|
+/// Same role as `Arrow`, but the wrapped function is `async`. The
+/// async driver in the main package (see `driver.mbt`) awaits the
+/// inner coroutine and threads it through the same shrink loop as the
+/// synchronous path.
+pub(all) struct ArrowAsync[A, B](async (A) -> B)
+
+///|
+/// A pair of values whose *equality under some relation* we are trying
+/// to establish. `Equivalence` is the data type behind the algebraic
+/// laws exposed in `axiom.mbt` — e.g.
+///
+///     // associativity of List concat
+///     fn assoc(xs : List[Int], ys : List[Int], zs : List[Int])
+///       -> Equivalence[List[Int]] {
+///       Equivalence::new((xs + ys) + zs, xs + (ys + zs))
+///     }
+///
+/// The driver then turns the `Equivalence` into a property via
+/// `Equivalence::to_property` (or `to_property_eq` when `T` implements
+/// `Eq` and you want pointwise equality as the relation).
+///
+/// `Equivalence` is a functor / applicative / monad: `fmap`, `ap`,
+/// `bind`, and `pure_eq` all live in `axiom.mbt`.
+///
+/// Fields:
+/// - `lhs`, `rhs`: the two candidates. The convention across the
+///   library is "what the user wrote on the left equals what the
+///   specification says on the right".
+pub(all) struct Equivalence[T] {
+  lhs : T
+  rhs : T
+}


### PR DESCRIPTION
## Summary

Moves the seven public, user-facing *type declarations* into a new \`src/types.mbt\` file, each with a 10–30 line docstring explaining what it represents, its fields, and how it plugs into the rest of the library. Methods, traits, and \`Show\` impls stay in the file that owns the behaviour, with a one-line pointer comment replacing the moved declaration.

## What moves

| Type | From | Purpose |
|------|------|---------|
| \`Outcome[T]\` | \`result.mbt\` | property run outcome (\`Success\` / \`GaveUp\` / \`Fail(t)\`) |
| \`Expected\` | \`result.mbt\` | author-declared expected outcome (\`expect=Fail\` knob) |
| \`Replay\` | \`result.mbt\` | RNG + size snapshot for deterministic re-runs |
| \`Arrow[A, B]\` | \`testable.mbt\` | pure-function property wrapper |
| \`ArrowError[A, B]\` | \`testable.mbt\` | raising-function property wrapper |
| \`ArrowAsync[A, B]\` | \`testable.mbt\` | async-function property wrapper |
| \`Equivalence[T]\` | \`axiom.mbt\` | lhs/rhs pair for algebraic laws |

## What stays

- \`Gen[T]\` — its struct body carries the primary-constructor declaration and every combinator method; splitting would cost more than it saves.
- Every *private* type (\`SingleResult\`, \`Property\`, \`State\`, \`Config\`, \`Printer\`, \`Axiom\`, \`Callback\`, \`Discard\`, \`TestError\`, \`TestSuccess\`, etc.) — implementation-local, stays with its behaviour.

## Test plan

- [x] \`moon check\` — 0 warnings
- [x] \`moon test\` — 247 / 247
- [x] \`moon fmt\` applied
- [x] \`moon info\` — \`pkg.generated.mbti\` unchanged (public API surface identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
