### PR TITLE
chore: drop src/internal exclude and bump to 0.11.3

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbitlang/quickcheck",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "readme": "README.md",
   "repository": "https://github.com/moonbitlang/quickcheck",
   "license": "Apache-2.0",
@@ -9,8 +9,5 @@
     "quickcheck"
   ],
   "description": "Automatic testing of MoonBit programs",
-  "source": "src",
-  "exclude": [
-    "src/internal"
-  ]
+  "source": "src"
 }


### PR DESCRIPTION
## Summary

- Drops \`\"exclude\": [\"src/internal\"]\` from \`moon.mod.json\`.
- Bumps patch version \`0.11.2\` → \`0.11.3\` for republishing.

## Rationale

MoonBit enforces Go-style \`internal/\` visibility at the module boundary. Live probe:

    Cannot import internal package moonbitlang/core/internal/strconv in
    moonbitlang/quickcheck/utils due to internal visibility rules

So external users already can't reach anything under \`moonbitlang/quickcheck/internal/...\`. The \`exclude\` was only keeping their source off the published tarball; since nothing under \`src/internal/\` (tests, tutorials, micro-benchmarks, ShrinkTree pretty-printer) is sensitive, the bloat is trivial and the extra config line implied an access-control role it never had.

## What ships now

77 files under \`src/\` (was 56), adding the internal test corpus and English / Chinese tutorials. No functional API changes.

## Test plan

- [x] \`moon check\` clean
- [x] \`moon test\` — 247 / 247
- [x] \`moon package --list\` verifies \`src/internal/\` is now included

Next step after merge: manually trigger the \`publish-package\` GitHub Action to push 0.11.3 to mooncakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
