### PR TITLE
fix: repoint README.md symlink after src/testing → src/internal/testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-./src/testing/tutorial_en/README.mbt.md
+./src/internal/testing/tutorial_en/README.mbt.md


### PR DESCRIPTION
## Summary

The top-level \`README.md\` is a symlink to the tutorial README. After #91 moved the tutorial tree from \`src/testing/\` to \`src/internal/testing/\`, the symlink was left dangling:

    README.md -> ./src/testing/tutorial_en/README.mbt.md   (target gone)

\`moon check\` and CI never resolve the link, so the regression went unnoticed. \`moon publish\` does stat it and fails with

    failed to read metadata while preserving unix permissions for README.md
    Error: \`moon publish\` failed

Repointing at the new location:

    README.md -> ./src/internal/testing/tutorial_en/README.mbt.md

This unblocks the 0.11.3 republish.

## Test plan

- [x] \`ls -la README.md\` resolves and \`cat README.md\` reads correctly
- [x] will retrigger the publish workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
