### PR TITLE
feat(feat): add Finite::iter for `for x in finite` sugar

### DIFF
--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -19,7 +19,7 @@ pub(all) struct Finite[T] {
 /// The empty chunk: cardinality zero, indexer that aborts. Identity
 /// for `fin_union`; absorbing element for `fin_cart`.
 pub fn[T] fin_empty() -> Finite[T] {
-  { fCard: 0, fIndex: fn(_x) { abort("index empty") } }
+  { fCard: 0, fIndex: _ => abort("index empty") }
 }
 
 ///|
@@ -153,6 +153,63 @@ pub fn[M] fin_mconcat(val : LazyList[Finite[M]]) -> Finite[M] {
   } else {
     fin
   }
+}
+
+///|
+/// Lazy traversal over the chunk: walks indices `0, 1, 2, …, fCard-1`
+/// and yields `fIndex(i)` at each step. Because MoonBit's
+/// `for x in <expr>` desugars to `<expr>.iter()`, this is what lets
+/// you use a `Finite[T]` directly with the loop sugar.
+///
+/// The traversal is lazy: early `break` stops calling `fIndex`.
+/// Like every `Iter` in MoonBit it is single-shot.
+pub fn[T] Finite::iter(self : Finite[T]) -> Iter[T] {
+  let card = self.fCard
+  let fi = self.fIndex
+  let mut i : BigInt = 0
+  Iter::new(() => {
+    if i < card {
+      let v = fi(i)
+      i = i + 1
+      Some(v)
+    } else {
+      None
+    }
+  })
+}
+
+///|
+test "iter walks 0..fCard" {
+  assert_eq(fin_finite(5).iter().collect(), [0, 1, 2, 3, 4])
+  let f : Finite[Int] = fin_empty()
+  assert_eq(f.iter().collect(), [])
+}
+
+///|
+test "for x in finite walks every element" {
+  let acc : Array[BigInt] = []
+  for x in fin_finite(3) {
+    acc.push(x)
+  }
+  assert_eq(acc, [0, 1, 2])
+}
+
+///|
+test "iter is lazy — early break stops walking" {
+  let calls = Ref::new(0)
+  let probe : Finite[Int] = {
+    fCard: 1000,
+    fIndex: fn(_i) {
+      calls.val = calls.val + 1
+      42
+    },
+  }
+  for _x in probe {
+    if calls.val == 3 {
+      break
+    }
+  }
+  assert_eq(calls.val, 3)
 }
 
 ///|

--- a/src/feat/pkg.generated.mbti
+++ b/src/feat/pkg.generated.mbti
@@ -61,6 +61,7 @@ pub(all) struct Finite[T] {
   fCard : @bigint.BigInt
   fIndex : (@bigint.BigInt) -> T
 }
+pub fn[T] Finite::iter(Self[T]) -> Iter[T]
 pub fn[T] Finite::op_add(Self[T], Self[T]) -> Self[T]
 pub fn[T] Finite::to_array(Self[T]) -> (@bigint.BigInt, @list.List[T])
 pub impl[T : Show] Show for Finite[T]


### PR DESCRIPTION
## Summary

Adds \`Finite::iter(self) -> Iter[T]\` that walks indices from 0 to \`fCard - 1\` and yields \`fIndex(i)\` at each step. Because MoonBit's \`for x in <expr>\` desugars to \`<expr>.iter()\`, this enables

\`\`\`moonbit
for x in finite_chunk {
  // …
}
\`\`\`

on any \`Finite[T]\` — the same \`Iter\`-based convention introduced for \`Rose\` earlier.

## Laziness

- \`break\` inside the loop stops calling \`fIndex\` immediately.
- Like every \`Iter\` in MoonBit, the result is single-shot.

## Tests

Three new whitebox tests in \`finite.mbt\`:

- \`iter walks 0..fCard\` — \`fin_finite(5)\` → \`[0, 1, 2, 3, 4]\`, empty \`Finite\` → \`[]\`.
- \`for x in finite walks every element\` — the loop sugar works.
- \`iter is lazy — early break stops walking\` — a probe \`Finite\` with 1000 elements that counts \`fIndex\` calls; after 3 iterations with \`break\`, exactly 3 calls are recorded.

## Test plan

- [x] \`moon check\` — 0 warnings
- [x] \`moon test\` — 250 / 250 (3 new)
- [x] \`moon fmt\` applied
- [x] \`moon info\` regenerated \`pkg.generated.mbti\` to expose \`Finite::iter\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
