### PR TITLE
feat(feat): add Add impl for Finite + iter sugar in docs

### DIFF
--- a/src/feat/README.mbt.md
+++ b/src/feat/README.mbt.md
@@ -111,8 +111,13 @@ test "fin_empty has cardinality 0" {
 test "disjoint union via fin_union" {
   let left = @feat.fin_finite(3) // [0, 1, 2]
   let right = @feat.fin_finite(2) // [0, 1]
-  let joined = @feat.fin_union(left, right) // [0, 1, 2, 0, 1]
-  inspect(joined.to_array(), content="(5, @list.from_array([0, 1, 2, 0, 1]))")
+  let joined = left + right // [0, 1, 2, 0, 1]
+  inspect(
+    [..joined],
+    content=(
+      #|[0, 1, 2, 0, 1]
+    ),
+  )
 }
 
 ///|
@@ -126,6 +131,22 @@ test "Cartesian product via fin_cart" {
       #|(6, @list.from_array([(0, 0), (0, 1), (0, 2), (1, 0), (1, 1), (1, 2)]))
     ),
   )
+}
+```
+
+Every `Finite[T]` is also iterable — `for x in finite { ... }` desugars
+to `finite.iter()`, which walks `fIndex(0)..fIndex(fCard - 1)` lazily.
+Use it whenever you want to stream a chunk's contents without
+materialising the full list via `to_array`:
+
+```mbt check
+///|
+test "for x in finite" {
+  let acc : Array[BigInt] = []
+  for x in @feat.fin_finite(4) {
+    acc.push(x)
+  }
+  assert_eq(acc, [0, 1, 2, 3])
 }
 ```
 

--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -46,10 +46,16 @@ pub fn[T] fin_union(f1 : Finite[T], f2 : Finite[T]) -> Finite[T] {
 }
 
 ///|
+#deprecated
+pub fn[T] Finite::op_add(self : Finite[T], other : Finite[T]) -> Finite[T] {
+  fin_union(self, other)
+}
+
+///|
 /// `+` as an alias for `fin_union`. Not an `Add` trait impl, because
 /// it's defined directly as a method on `Finite[T]` for `T` generic
 /// over any type (not constrained to `Add`).
-pub fn[T] Finite::op_add(self : Finite[T], other : Finite[T]) -> Finite[T] {
+pub impl[T] Add for Finite[T] with add(self, other) {
   fin_union(self, other)
 }
 

--- a/src/feat/pkg.generated.mbti
+++ b/src/feat/pkg.generated.mbti
@@ -62,8 +62,10 @@ pub(all) struct Finite[T] {
   fIndex : (@bigint.BigInt) -> T
 }
 pub fn[T] Finite::iter(Self[T]) -> Iter[T]
+#deprecated
 pub fn[T] Finite::op_add(Self[T], Self[T]) -> Self[T]
 pub fn[T] Finite::to_array(Self[T]) -> (@bigint.BigInt, @list.List[T])
+pub impl[T] Add for Finite[T]
 pub impl[T : Show] Show for Finite[T]
 
 // Type aliases


### PR DESCRIPTION
## Summary

Follow-up to #96. Three small tweaks that round out the \`Finite::iter\` work:

- **\`impl[T] Add for Finite[T]\`** — lets users write \`left + right\` instead of the helper \`fin_union(left, right)\`. The standalone \`Finite::op_add\` method is kept but marked \`#deprecated\` for callers that haven't migrated.

- **\`src/feat/README.mbt.md\`**:
  - Switch the \`fin_union\` example to use \`left + right\` and the iter-backed \`[..joined]\` spread syntax.
  - Add a short "for x in finite" example under the \`Finite\` section so readers notice the new iterator sugar.

- **\`src/falsify/README.mbt.md\`** — drop a stray \`z\` typo on line 254.

## Test plan

- [x] \`moon check\` — 0 warnings
- [x] \`moon test\` — 251 / 251 (one new doctest)
- [x] \`moon fmt\` applied
- [x] \`moon info\` regenerated \`pkg.generated.mbti\` to reflect the \`Add\` impl + deprecation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
