### PR TITLE
feat: API cleanup — rename en_index → at, add LazyList::iter, deprecate pair_function

### DIFF
--- a/src/feat/README.mbt.md
+++ b/src/feat/README.mbt.md
@@ -250,7 +250,7 @@ Three rules, and that's it:
 
 1. **One `+` summand per constructor.** Leaf constructors become
    `singleton(...)`; constructors that carry children use
-   `unary(@utils.pair_function(...))` or `product(...)`.
+   `unary(pair => Cons(pair.0, pair.1))` or `product(...)`.
 2. **Wrap the whole thing in a `pay(...)`.** The `pay` is what gives the
    fixpoint a chance to suspend before recursing into `T::enumerate()`
    again — this is the productivity guarantee (contract item 2).
@@ -273,9 +273,9 @@ impl @feat.Enumerable for Tree with enumerate() {
   // `unary`, which goes through the built-in `Enumerable` instance for
   // `(Tree, Tree)`. That instance itself inserts a `pay`, which is what keeps
   // the fixpoint productive.
-  @feat.pay(fn() {
-    let mk = @utils.pair_function((l : Tree, r : Tree) => Node(l, r))
-    @feat.singleton(Leaf) + @feat.unary(mk)
+  @feat.pay(() => {
+    @feat.singleton(Leaf) +
+    @feat.unary((pair : (Tree, Tree)) => Node(pair.0, pair.1))
   })
 }
 

--- a/src/feat/README.mbt.md
+++ b/src/feat/README.mbt.md
@@ -180,7 +180,7 @@ test "pay shifts everything one size up" {
 
 > **This is the main user-facing trait of the package.** Implement
 > `Enumerable` for a type `T` and you get: indexed access
-> (`en_index(i)`), size-bounded sampling via `feat_random`, and a
+> (`enumerate()[i]`), size-bounded sampling via `feat_random`, and a
 > ready-to-use `Gen[T]` for the top-level QuickCheck driver. Everything
 > else in this package either consumes or produces an `Enumerable`.
 
@@ -208,7 +208,7 @@ use it safely:
 |---|----------|-------------------------------|
 | 1 | **Cardinalities are non-negative.** Every part has `fCard : BigInt` and must satisfy `fCard >= 0`. Parts with `fCard == 0` are empty and collapse away. | The package assumes every part behaves like a finite set; a negative card produced by hand breaks that model and will lead to wrong indexing behaviour. |
 | 2 | **Productivity under recursion.** Every recursive self-reference inside an `Enumerable` instance must be guarded by a `pay(...)`. An `Enumerate[T]` is a `LazyList` of parts, so it may be infinite — but each part must be reachable in finite time. | Evaluating `enumerate()` blows the stack or loops forever. |
-| 3 | **Total indexing per part.** For every `i` with `0 <= i < part.fCard`, `part.fIndex(i)` must return a valid `T`. | `en_index` aborts with "index out of bounds". |
+| 3 | **Total indexing per part.** For every `i` with `0 <= i < part.fCard`, `part.fIndex(i)` must return a valid `T`. | Indexing aborts with "index out of bounds". |
 
 These are the same invariants that the provided combinators already
 preserve — so if you stick to `singleton`, `union` / `+`, `product`,
@@ -296,8 +296,8 @@ impl Show for Tree with output(self, logger) {
 ///|
 test "enumerate the first few binary trees" {
   let trees : @feat.Enumerate[Tree] = Enumerable::enumerate()
-  inspect(trees.en_index(0), content="Leaf")
-  inspect(trees.en_index(1), content="Node(Leaf, Leaf)")
+  inspect(trees[0], content="Leaf")
+  inspect(trees[1], content="Node(Leaf, Leaf)")
 }
 ```
 
@@ -325,25 +325,25 @@ test "enumerate the first few binary trees" {
 
 ### Indexing
 
-`Enumerate::en_index(i)` is the "i-th value, overall" view. Sizes are walked
-in order: all size-0 values, then all size-1 values, etc.
+`Enumerate::at(i)` (also written `e[i]`) is the "i-th value, overall" view.
+Sizes are walked in order: all size-0 values, then all size-1 values, etc.
 
 ```mbt check
 ///|
 test "index into Bool's enumeration" {
   // Enumerable::enumerate() for Bool yields [true, false] (inside pay).
   let e : @feat.Enumerate[Bool] = Enumerable::enumerate()
-  inspect(e.en_index(0), content="true")
-  inspect(e.en_index(1), content="false")
+  inspect(e[0], content="true")
+  inspect(e[1], content="false")
 }
 
 ///|
 test "index into a list enumeration" {
   let e : @feat.Enumerate[@list.List[Bool]] = Enumerable::enumerate()
   // Sizes grow as more cons cells are added.
-  inspect(e.en_index(0), content="@list.from_array([])")
-  inspect(e.en_index(1), content="@list.from_array([true])")
-  inspect(e.en_index(2), content="@list.from_array([false])")
+  inspect(e[0], content="@list.from_array([])")
+  inspect(e[1], content="@list.from_array([true])")
+  inspect(e[2], content="@list.from_array([false])")
 }
 ```
 
@@ -385,17 +385,17 @@ size-aware Cartesian `product`:
 test "fmap rewrites every element in place" {
   let bools : @feat.Enumerate[Bool] = Enumerable::enumerate()
   let labels = bools.fmap(b => if b { "yes" } else { "no" })
-  assert_eq(labels.en_index(0), "yes")
-  assert_eq(labels.en_index(1), "no")
+  assert_eq(labels[0], "yes")
+  assert_eq(labels[1], "no")
 }
 
 ///|
 test "product generates every pair in part order" {
   let pairs = @feat.product(zero_or_one_part(), zero_or_one_part())
-  inspect(pairs.en_index(0), content="(0, 0)")
-  inspect(pairs.en_index(1), content="(0, 1)")
-  inspect(pairs.en_index(2), content="(1, 0)")
-  inspect(pairs.en_index(3), content="(1, 1)")
+  inspect(pairs[0], content="(0, 0)")
+  inspect(pairs[1], content="(0, 1)")
+  inspect(pairs[2], content="(1, 0)")
+  inspect(pairs[3], content="(1, 1)")
 }
 
 ///|
@@ -416,7 +416,7 @@ fn zero_or_one_part() -> @feat.Enumerate[BigInt] {
 
 | Situation | Prefer |
 |-----------|--------|
-| "Try every value up to size 10." | Feat (`en_index` in a loop) |
+| "Try every value up to size 10." | Feat (indexing in a loop) |
 | "Find a counterexample in a space I can't enumerate in reasonable time." | QuickCheck (random `Arbitrary`) |
 | "Deterministic, reproducible fuzz corpus across runs." | Feat (size-indexed, no RNG) |
 | "I need shrinking to a small counterexample." | QuickCheck + `Shrink` or `falsify` |

--- a/src/feat/enumerable.mbt
+++ b/src/feat/enumerable.mbt
@@ -108,11 +108,7 @@ pub impl[E : Enumerable] Enumerable for @moonbitlang/core/list.List[E] with enum
   consts(
     @list.from_array([
       singleton(@list.empty()),
-      unary(
-        @utils.pair_function(fn(e : E, lst : @moonbitlang/core/list.List[E]) {
-          lst.add(e)
-        }),
-      ),
+      unary((pair : (E, @moonbitlang/core/list.List[E])) => pair.1.add(pair.0)),
     ]),
   )
 }

--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -43,7 +43,9 @@ pub fn[T] singleton(val : T) -> Enumerate[T] {
 /// inside the current part, then read the value via `fIndex`.
 ///
 /// **Aborts** on out-of-range indices (reaches `Nil`).
-pub fn[T] Enumerate::en_index(self : Enumerate[T], idx : BigInt) -> T {
+#alias("_[_]")
+#alias(en_index,deprecated = "Use `_[_]` instead")
+pub fn[T] Enumerate::at(self : Enumerate[T], idx : BigInt) -> T {
   for parts = self.parts, i = idx {
     match parts {
       Nil => abort("index out of bounds")

--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -142,10 +142,10 @@ pub fn[T] consts(ls : @list.List[Enumerate[T]]) -> Enumerate[T] {
 
 ///|
 /// Apply a unary constructor: `unary(f) == T::enumerate().fmap(f)`.
-/// For multi-argument constructors, wrap via `pair_function` so `f`
-/// takes a single tuple argument — then `unary(f)` goes through the
-/// built-in pair `Enumerable` instance which inserts the required
-/// `pay`.
+/// For multi-argument constructors, write a tuple lambda so `f` takes
+/// a single tuple argument — e.g. `unary(p => Node(p.0, p.1))` — then
+/// `unary(f)` goes through the built-in pair `Enumerable` instance
+/// which inserts the required `pay`.
 pub fn[T : Enumerable, U] unary(f : (T) -> U) -> Enumerate[U] {
   T::enumerate().fmap(f)
 }

--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -44,7 +44,7 @@ pub fn[T] singleton(val : T) -> Enumerate[T] {
 ///
 /// **Aborts** on out-of-range indices (reaches `Nil`).
 #alias("_[_]")
-#alias(en_index,deprecated = "Use `_[_]` instead")
+#alias(en_index, deprecated="Use `_[_]` instead")
 pub fn[T] Enumerate::at(self : Enumerate[T], idx : BigInt) -> T {
   for parts = self.parts, i = idx {
     match parts {

--- a/src/feat/moon.pkg
+++ b/src/feat/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/quickcheck/internal/lazy",
-  "moonbitlang/quickcheck/internal/utils",
   "moonbitlang/core/list",
 }
 

--- a/src/feat/pkg.generated.mbti
+++ b/src/feat/pkg.generated.mbti
@@ -26,7 +26,9 @@ pub fn[T : Enumerable, U] unary((T) -> U) -> Enumerate[U]
 pub(all) struct Enumerate[T] {
   parts : @lazy.LazyList[Finite[T]]
 }
-pub fn[T] Enumerate::en_index(Self[T], @bigint.BigInt) -> T
+#alias("_[_]")
+#alias(en_index, deprecated)
+pub fn[T] Enumerate::at(Self[T], @bigint.BigInt) -> T
 pub fn[T] Enumerate::eval(Self[T]) -> @lazy.LazyList[Finite[T]]
 pub fn[T, U] Enumerate::fmap(Self[T], (T) -> U) -> Self[U]
 pub fn[T] Enumerate::sample_finite(Self[T], Int) -> Finite[T]

--- a/src/internal/benchmark/feat.mbt
+++ b/src/internal/benchmark/feat.mbt
@@ -6,14 +6,13 @@ priv enum Nat {
 
 ///|
 impl @feat.Enumerable for Nat with enumerate() {
-  @feat.pay(fn() {
-    @feat.singleton(Zero) +
-    @feat.Enumerable::enumerate().fmap(fn(n) { Succ(n) })
+  @feat.pay(() => {
+    @feat.singleton(Zero) + @feat.Enumerable::enumerate().fmap(n => Succ(n))
   })
 }
 
 ///|
 test (b : @bench.T) {
   let f : @feat.Enumerate[Nat] = @feat.Enumerable::enumerate()
-  b.bench(name="feat nat", fn() { f[200] |> ignore })
+  b.bench(name="feat nat", () => f[200] |> ignore)
 }

--- a/src/internal/benchmark/feat.mbt
+++ b/src/internal/benchmark/feat.mbt
@@ -15,5 +15,5 @@ impl @feat.Enumerable for Nat with enumerate() {
 ///|
 test (b : @bench.T) {
   let f : @feat.Enumerate[Nat] = @feat.Enumerable::enumerate()
-  b.bench(name="feat nat", fn() { f.en_index(200) |> ignore })
+  b.bench(name="feat nat", fn() { f[200] |> ignore })
 }

--- a/src/internal/lazy/README.mbt.md
+++ b/src/internal/lazy/README.mbt.md
@@ -169,6 +169,38 @@ test "tails exposes every suffix" {
 }
 ```
 
+### Loop sugar with `for x in`
+
+`LazyList::iter(self) -> Iter[T]` walks the list head-first, yielding
+each element on demand. MoonBit's `for x in <expr>` desugars to
+`<expr>.iter()`, so any `LazyList` plays directly with the loop sugar.
+Cells are forced as the iterator advances, so an early `break` (or
+pairing with `take`) avoids touching the rest.
+
+```mbt check
+///|
+test "for x in walks every element" {
+  let xs = @lazy.from_list(@list.from_array([10, 20, 30]))
+  let acc = []
+  for x in xs {
+    acc.push(x)
+  }
+  inspect(acc, content="[10, 20, 30]")
+}
+
+///|
+test "iter is lazy — early break works on infinite input" {
+  let mut last = -1
+  for x in @lazy.infinite_stream(0, 1) {
+    last = x
+    if x == 3 {
+      break
+    }
+  }
+  assert_eq(last, 3)
+}
+```
+
 ### Folding
 
 Standard left/right folds. Right-fold is defined naively so it should be
@@ -259,6 +291,7 @@ test "unfold builds a countdown" {
 | `head` / `tail` | `LazyList[T] -> T` / `LazyList[T]` | Panics on `Nil` |
 | `length` | `LazyList[T] -> Int` | Forces the entire list |
 | `index` | `LazyList[T] -> Int -> T` | O(n) |
+| `iter` | `LazyList[T] -> Iter[T]` | Single-shot lazy traversal — enables `for x in` |
 | `take` / `drop` / `split_at` | count-indexed slicing | Preserves laziness |
 | `take_while` / `drop_while` | predicate-indexed slicing | Stops at first failure |
 | `map` | `(T -> U) -> LazyList[T] -> LazyList[U]` | Lazy |

--- a/src/internal/lazy/lazy_list.mbt
+++ b/src/internal/lazy/lazy_list.mbt
@@ -41,6 +41,31 @@ pub impl[T : Show] Show for LazyList[T] with output(self, logger) {
 }
 
 ///|
+/// Lazy traversal: walks the list head-first, yielding each element
+/// as the iterator is pulled. Because MoonBit's `for x in <expr>`
+/// desugars to `<expr>.iter()`, this enables
+///
+///     for x in lazy_list { ... }
+///
+/// on any `LazyList[T]`.
+///
+/// Only the cells actually consumed are forced — pairing with `take`
+/// or breaking out of the loop early avoids touching the rest. Like
+/// every `Iter` in MoonBit it is single-shot.
+pub fn[T] LazyList::iter(self : LazyList[T]) -> Iter[T] {
+  let mut cur = self
+  Iter::new(() => {
+    match cur {
+      Nil => None
+      Cons(x, xs) => {
+        cur = xs.force()
+        Some(x)
+      }
+    }
+  })
+}
+
+///|
 /// Return the element at position `i`. **O(n)** — walks the list from
 /// the head. Aborts if `i` is negative or past the end.
 pub fn[T] LazyList::index(self : LazyList[T], i : Int) -> T {

--- a/src/internal/lazy/pkg.generated.mbti
+++ b/src/internal/lazy/pkg.generated.mbti
@@ -38,6 +38,7 @@ pub fn[T, U] LazyList::fold_left(Self[T], (U, T) -> U, init~ : U) -> U
 pub fn[T, U] LazyList::fold_right(Self[T], (T, U) -> U, init~ : U) -> U
 pub fn[T] LazyList::head(Self[T]) -> T
 pub fn[T] LazyList::index(Self[T], Int) -> T
+pub fn[T] LazyList::iter(Self[T]) -> Iter[T]
 pub fn[T] LazyList::length(Self[T]) -> Int
 pub fn[T, U] LazyList::map(Self[T], (T) -> U) -> Self[U]
 pub fn[T] LazyList::split_at(Self[T], Int) -> (Self[T], Self[T])

--- a/src/internal/testing/README.mbt.md
+++ b/src/internal/testing/README.mbt.md
@@ -64,7 +64,7 @@ be imported across the module boundary.
 | `internal/shrinking` | Experimental `ShrinkTree[T]` pretty-printer used when exploring shrink traces |
 | `internal/lazy` | Call-by-need values and lazy lists used by `feat` and `falsify` |
 | `internal/rose` | Shrink-tree structure used by the main QuickCheck driver |
-| `internal/utils` | Shared combinators (`id`, `flip`, `pair_function`, …) and chunk-wise shrink helpers |
+| `internal/utils` | Shared combinators (`id`, `flip`, …) and chunk-wise shrink helpers |
 
 New non-public packages should land under `src/internal/` as well —
 that's the single namespace the visibility rule covers.

--- a/src/internal/testing/feat.mbt
+++ b/src/internal/testing/feat.mbt
@@ -18,7 +18,7 @@ test "feat nat" {
 
 ///|
 test "feat nat index" {
-  let x = [0N, 1, 2, 3, 4, 5, 6].map(fn(x) {
+  let x = [0N, 1, 2, 3, 4, 5, 6].map(x => {
     (@feat.Enumerable::enumerate() : @feat.Enumerate[Nat])[x]
   })
   inspect(
@@ -30,28 +30,28 @@ test "feat nat index" {
 ///|
 test "feat int index order" {
   let e : @feat.Enumerate[Int] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3, 4, 5].map(fn(i) { e[i] })
+  let xs = [0N, 1, 2, 3, 4, 5].map(i => e[i])
   inspect(xs, content="[0, 1, -1, 2, -2, 3]")
 }
 
 ///|
 test "feat byte index order" {
   let e : @feat.Enumerate[Byte] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3].map(fn(i) { e[i] })
+  let xs = [0N, 1, 2, 3].map(i => e[i])
   inspect(xs, content="[b'\\x00', b'\\x01', b'\\x02', b'\\x03']")
 }
 
 ///|
 test "feat char index order" {
   let e : @feat.Enumerate[Char] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3].map(fn(i) { e[i] })
+  let xs = [0N, 1, 2, 3].map(i => e[i])
   inspect(xs, content="['\\u{00}', '\\u{01}', '\\u{02}', '\\u{03}']")
 }
 
 ///|
 test "enumerate int" {
   let gen : @feat.Enumerate[Int] = @feat.Enumerable::enumerate()
-  let arr = Array::makei(10, fn(i) { gen[BigInt::from_int(i)] })
+  let arr = Array::makei(10, i => gen[BigInt::from_int(i)])
   inspect(arr, content="[0, 1, -1, 2, -2, 3, -3, 4, -4, 5]")
 }
 
@@ -130,14 +130,12 @@ impl[T : Show] Show for Forest[T] with output(self, logger) {
 
 ///|
 impl[E : @feat.Enumerable] @feat.Enumerable for Forest[E] with enumerate() {
-  @feat.pay(fn() {
-    @feat.Enumerable::enumerate().fmap(fn(forest) { { forest, } })
-  })
+  @feat.pay(() => @feat.Enumerable::enumerate().fmap(forest => { forest, }))
 }
 
 ///|
 impl[E : @feat.Enumerable] @feat.Enumerable for Tree[E] with enumerate() {
-  @feat.pay(fn() {
+  @feat.pay(() => {
     E::enumerate().fmap(x => Leaf(x)) +
     @feat.Enumerable::enumerate().fmap(x => Branch(x))
   })

--- a/src/internal/testing/feat.mbt
+++ b/src/internal/testing/feat.mbt
@@ -19,7 +19,7 @@ test "feat nat" {
 ///|
 test "feat nat index" {
   let x = [0N, 1, 2, 3, 4, 5, 6].map(fn(x) {
-    (@feat.Enumerable::enumerate() : @feat.Enumerate[Nat]).en_index(x)
+    (@feat.Enumerable::enumerate() : @feat.Enumerate[Nat])[x]
   })
   inspect(
     x,
@@ -30,28 +30,28 @@ test "feat nat index" {
 ///|
 test "feat int index order" {
   let e : @feat.Enumerate[Int] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3, 4, 5].map(fn(i) { e.en_index(i) })
+  let xs = [0N, 1, 2, 3, 4, 5].map(fn(i) { e[i] })
   inspect(xs, content="[0, 1, -1, 2, -2, 3]")
 }
 
 ///|
 test "feat byte index order" {
   let e : @feat.Enumerate[Byte] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3].map(fn(i) { e.en_index(i) })
+  let xs = [0N, 1, 2, 3].map(fn(i) { e[i] })
   inspect(xs, content="[b'\\x00', b'\\x01', b'\\x02', b'\\x03']")
 }
 
 ///|
 test "feat char index order" {
   let e : @feat.Enumerate[Char] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3].map(fn(i) { e.en_index(i) })
+  let xs = [0N, 1, 2, 3].map(fn(i) { e[i] })
   inspect(xs, content="['\\u{00}', '\\u{01}', '\\u{02}', '\\u{03}']")
 }
 
 ///|
 test "enumerate int" {
   let gen : @feat.Enumerate[Int] = @feat.Enumerable::enumerate()
-  let arr = Array::makei(10, fn(i) { gen.en_index(BigInt::from_int(i)) })
+  let arr = Array::makei(10, fn(i) { gen[BigInt::from_int(i)] })
   inspect(arr, content="[0, 1, -1, 2, -2, 3, -3, 4, -4, 5]")
 }
 
@@ -156,7 +156,7 @@ test "feat tree random" {
 test "feat tree" {
   let fe : @qc.Gen[Tree[Nat]] = @qc.Gen::feat_random(11)
   inspect(fe.sample(), content="Leaf(Succ(Succ(Succ(Succ(Zero)))))")
-  let x : SingleTree = @feat.Enumerable::enumerate().en_index(196606)
+  let x : SingleTree = @feat.Enumerable::enumerate()[196606]
   inspect(
     x,
     content="Node(false, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Node(true, Leaf(true)))))))))))))))))",
@@ -167,6 +167,6 @@ test "feat tree" {
 test "index large" {
   let eTree : @feat.Enumerate[SingleTree] = @feat.Enumerable::enumerate()
   for i = 100000N; i > 0; i = i - 1 {
-    eTree.en_index(i) |> ignore
+    eTree[i] |> ignore
   }
 }

--- a/src/internal/testing/feat.mbt
+++ b/src/internal/testing/feat.mbt
@@ -84,14 +84,9 @@ impl @feat.Enumerable for SingleTree with enumerate() {
   @feat.consts(
     @list.from_array([
       @feat.Enumerable::enumerate().fmap(x => Leaf(x)),
-      @feat.unary(pair_function((x, y) => Node(x, y))),
+      @feat.unary((p : (Bool, SingleTree)) => Node(p.0, p.1)),
     ]),
   )
-}
-
-///|
-fn[A, B, C] pair_function(f : (A, B) -> C) -> ((A, B)) -> C {
-  fn(x : (A, B)) -> C { f(x.0, x.1) }
 }
 
 ///|

--- a/src/internal/testing/tutorial_en/Tutorial3.mbt.md
+++ b/src/internal/testing/tutorial_en/Tutorial3.mbt.md
@@ -372,7 +372,7 @@ pub(open) trait Enumerable {
   enumerate() -> @feat.Enumerate[Self]
 }
 
-pub fn[T] @feat.Enumerate::en_index(Self[T], BigInt) -> T
+pub fn[T] @feat.Enumerate::at(Self[T], BigInt) -> T
 ```
 
 A good enumerator should satisfy at least three conditions. First, it should avoid duplicates. Otherwise the supposedly exhaustive prefix wastes budget revisiting the same values. Second, each size layer should be finite. Otherwise SmallCheck can get stuck on one layer forever and never reach larger values. Third, the enumeration order should track a reasonable notion of complexity, so that early values really do look like the small samples we want to prioritize.
@@ -401,7 +401,7 @@ impl @feat.Enumerable for PeanoNat with enumerate() {
 ///|
 test "peano enumerate order" {
   let e : @feat.Enumerate[PeanoNat] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3, 4].map(i => e.en_index(i))
+  let xs = [0N, 1, 2, 3, 4].map(i => e[i])
   debug_inspect(
     xs,
     content=(
@@ -425,7 +425,7 @@ For more complicated data types, the overall pattern is still fairly mechanical.
 
 The `Enumerable` interface above is not ad hoc. It is essentially MoonBit’s realization of the functional-enumeration approach from _Feat: Functional Enumeration of Algebraic Types_. Instead of treating a type as one long linear list of values, Feat represents it as a sequence of finite parts grouped by size. Each part carries two key pieces of information: its cardinality and an indexing function.
 
-MoonBit’s current implementation follows exactly that shape. Internally, `Enumerate[T]` is a lazy stream of parts, and each `Finite[T]` carries two consumers, `fCard` and `fIndex`. That makes the behavior of global indexing via `en_index` quite clear. The implementation does not generate every earlier value one by one. Instead, it skips whole parts using their cardinalities, then indexes directly inside the part that contains the requested value. This is the "function view" from the paper, and it is fundamentally different from the list view used in many SmallCheck-style implementations.
+MoonBit’s current implementation follows exactly that shape. Internally, `Enumerate[T]` is a lazy stream of parts, and each `Finite[T]` carries two consumers, `fCard` and `fIndex`. That makes the behavior of global indexing via `Enumerate::at` (the `_[_]` operator) quite clear. The implementation does not generate every earlier value one by one. Instead, it skips whole parts using their cardinalities, then indexes directly inside the part that contains the requested value. This is the "function view" from the paper, and it is fundamentally different from the list view used in many SmallCheck-style implementations.
 
 That design has two immediate benefits. First, enumeration is not limited to scanning from the front; it also supports random access. Second, the same enumerator can support multiple testing strategies, including prefix enumeration and size-bounded random sampling through APIs such as `@qc.Gen::feat_random`. In that sense, Feat is not a separate testing framework. It is a shared data-generation substrate.
 

--- a/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
@@ -527,7 +527,7 @@ impl @feat.Enumerable for Nat with enumerate() {
 ///|
 test "nat enumerate order" {
   let e : @feat.Enumerate[Nat] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3, 4].map(fn(i) { e[i] })
+  let xs = [0N, 1, 2, 3, 4].map(i => e[i])
   inspect(
     xs,
     content="[Zero, Succ(Zero), Succ(Succ(Zero)), Succ(Succ(Succ(Zero))), Succ(Succ(Succ(Succ(Zero))))]",

--- a/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
@@ -482,7 +482,7 @@ pub(open) trait Enumerable {
   enumerate() -> @feat.Enumerate[Self]
 }
 
-pub fn[T] @feat.Enumerate::en_index(Self[T], BigInt) -> T
+pub fn[T] @feat.Enumerate::at(Self[T], BigInt) -> T
 ```
 
 一个好的 enumerator 至少要满足三点。第一，枚举结果不应重复，
@@ -527,7 +527,7 @@ impl @feat.Enumerable for Nat with enumerate() {
 ///|
 test "nat enumerate order" {
   let e : @feat.Enumerate[Nat] = @feat.Enumerable::enumerate()
-  let xs = [0N, 1, 2, 3, 4].map(fn(i) { e.en_index(i) })
+  let xs = [0N, 1, 2, 3, 4].map(fn(i) { e[i] })
   inspect(
     xs,
     content="[Zero, Succ(Zero), Succ(Succ(Zero)), Succ(Succ(Succ(Zero))), Succ(Succ(Succ(Succ(Zero))))]",
@@ -561,7 +561,7 @@ SmallCheck 在理论上甚至无法完成这一层的枚举。
 MoonBit 当前的实现也正是这样组织的。
 `Enumerate[T]` 内部是一条惰性的 parts 序列，而每个 `Finite[T]`
 则携带 `fCard` 与 `fIndex` 两个消费者。
-于是全局索引 `en_index` 的语义就很清楚了：
+于是全局索引 `Enumerate::at`（即 `_[_]` 算符）的语义就很清楚了：
 它不是从头把所有值一个个生成出来，而是先根据各 part 的基数跳过整层，
 再在命中的那一层里直接做索引。
 这正是论文所谓的 function view，它和 SmallCheck 常见的 list view 有本质差异。

--- a/src/internal/utils/README.mbt.md
+++ b/src/internal/utils/README.mbt.md
@@ -15,7 +15,7 @@ and were worth factoring out.
 flowchart TD
   qc["moonbitlang/quickcheck"] --> utils
   feat["moonbitlang/quickcheck/feat"] --> utils
-  utils["moonbitlang/quickcheck/internal/utils<br/>• id, const_, flip, pair_function<br/>• fresh_name<br/>• removes_list / removes_array<br/>• apply_while_list / apply_while_array"]
+  utils["moonbitlang/quickcheck/internal/utils<br/>• id, const_, flip<br/>• fresh_name<br/>• removes_list / removes_array<br/>• apply_while_list / apply_while_array"]
 ```
 
 Keeping these helpers in a single `internal` package means every
@@ -31,7 +31,8 @@ surface area of the main library.
 | `id(x)` | `T -> T` | The identity function |
 | `const_(t)(_)` | `T -> U -> T` | Ignore the second argument, return the first |
 | `flip(f)(x, y)` | `((A, B) -> C) -> (B, A) -> C` | Swap argument order |
-| `pair_function(f)((a, b))` | `((A, B) -> C) -> ((A, B)) -> C` | Re-pack a 2-arg function to take a tuple |
+
+> `pair_function` is **deprecated** — inline `tuple => f(tuple.0, tuple.1)` at the call site instead.
 
 ```mbt check
 ///|
@@ -53,13 +54,6 @@ test "flip swaps argument order" {
   let rsub = @utils.flip(sub)
   assert_eq(sub(10, 3), 7)
   assert_eq(rsub(10, 3), -7)
-}
-
-///|
-test "pair_function un-curries onto a tuple" {
-  let add = (x : Int, y : Int) => x + y
-  let add_pair = @utils.pair_function(add)
-  assert_eq(add_pair((4, 5)), 9)
 }
 ```
 
@@ -175,7 +169,7 @@ test "apply_while_array accumulates in reverse order" {
 | `id` | `T -> T` |
 | `const_` | `T -> (U -> T)` |
 | `flip` | `((A, B) -> C) -> (B, A) -> C` |
-| `pair_function` | `((A, B) -> C) -> ((A, B)) -> C` |
+| `pair_function` _(deprecated)_ | `((A, B) -> C) -> ((A, B)) -> C` |
 
 ### State & names
 
@@ -199,9 +193,6 @@ function listed above is a plain top-level `fn[...]`. That's
 deliberate — these are low-level combinators that sit below the
 trait-driven layers of the ecosystem:
 
-- `@feat.Enumerable` pulls `pair_function` in when expressing recursive
-  instances whose constructors take multiple children; see the `feat`
-  README's "Implementing Enumerable for your own type" section.
 - The classical shrinkers used by `moonbitlang/quickcheck.Shrink`
   (defined in `src/shrink.mbt`) reach for `removes_array` /
   `removes_list` to build "drop a chunk" candidates.

--- a/src/internal/utils/common.mbt
+++ b/src/internal/utils/common.mbt
@@ -132,10 +132,9 @@ pub fn[T, U] const_(t : T) -> (U) -> T {
 }
 
 ///|
-/// Convert an ordinary 2-argument function into one that accepts a
-/// tuple, i.e. `pair_function(f)((a, b)) == f(a, b)`. Handy for wiring
-/// combinators like `Enumerate::fmap` / `feat.unary` that operate on a
-/// single value but where the callee is expressed as two arguments.
+/// Deprecated. Inline as `tuple => f(tuple.0, tuple.1)` at the call
+/// site — the helper saves no characters and obscures the shape.
+#deprecated("Inline `tuple => f(tuple.0, tuple.1)` at the call site")
 pub fn[A, B, C] pair_function(f : (A, B) -> C) -> ((A, B)) -> C {
   tuple => f(tuple.0, tuple.1)
 }

--- a/src/internal/utils/pkg.generated.mbti
+++ b/src/internal/utils/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub fn fresh_name() -> String
 
 pub fn[T] id(T) -> T
 
+#deprecated
 pub fn[A, B, C] pair_function((A, B) -> C) -> ((A, B)) -> C
 
 pub fn[T] removes_array(Int, Int, Array[T]) -> Array[Array[T]]

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -146,17 +146,11 @@ type TestError
 
 // Types and methods
 pub(all) struct Arrow[A, B]((A) -> B)
-#deprecated
-pub fn[A, B] Arrow::inner(Self[A, B]) -> (A) -> B
 pub impl[P : Testable, A : @moonbitlang/core/quickcheck.Arbitrary + Shrink + Show] Testable for Arrow[A, P]
 
 pub(all) struct ArrowAsync[A, B](async (A) -> B)
-#deprecated
-pub fn[A, B] ArrowAsync::inner(Self[A, B]) -> async (A) -> B
 
 pub(all) struct ArrowError[A, B]((A) -> B raise)
-#deprecated
-pub fn[A, B] ArrowError::inner(Self[A, B]) -> (A) -> B raise
 pub impl[P : Testable, A : @moonbitlang/core/quickcheck.Arbitrary + Shrink + Show] Testable for ArrowError[A, P]
 
 type Callback

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -146,11 +146,17 @@ type TestError
 
 // Types and methods
 pub(all) struct Arrow[A, B]((A) -> B)
+#deprecated
+pub fn[A, B] Arrow::inner(Self[A, B]) -> (A) -> B
 pub impl[P : Testable, A : @moonbitlang/core/quickcheck.Arbitrary + Shrink + Show] Testable for Arrow[A, P]
 
 pub(all) struct ArrowAsync[A, B](async (A) -> B)
+#deprecated
+pub fn[A, B] ArrowAsync::inner(Self[A, B]) -> async (A) -> B
 
 pub(all) struct ArrowError[A, B]((A) -> B raise)
+#deprecated
+pub fn[A, B] ArrowError::inner(Self[A, B]) -> (A) -> B raise
 pub impl[P : Testable, A : @moonbitlang/core/quickcheck.Arbitrary + Shrink + Show] Testable for ArrowError[A, P]
 
 type Callback


### PR DESCRIPTION
## Summary
- **`Enumerate::en_index` → `Enumerate::at`** with a `_[_]` operator alias (`e[i]`); the old name is kept as a deprecated alias. All in-tree callers, README, and tutorials migrated to bracket syntax.
- **`LazyList::iter`** so `for x in lazy_list { ... }` works (matches the convention of `Finite::iter` and `Rose::iter`). Walks lazily, so early `break` on an `infinite_stream` doesn't blow up.
- **Style pass** converting the touched `fn(x) { body }` callbacks to arrow form `x => body`, plus `moon fmt`.
- **`@utils.pair_function`** marked `#deprecated` and inlined at the three remaining call sites as a plain tuple lambda. The unused `@utils` import is dropped from `src/feat/moon.pkg`.

## Test plan
- [x] `moon check` — clean (was 23 deprecation warnings before)
- [x] `moon test` — 252/252 pass (one test removed alongside the deprecated `pair_function` example; one net new test added for `LazyList::iter`)
- [x] `moon fmt` — applied
- [x] `moon info` — regenerated `pkg.generated.mbti` for `feat` and `internal/utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
