### PR TITLE
style: convert remaining fn(...) callbacks to arrow form

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -294,7 +294,7 @@ pub fn[A : @feat.Enumerable + Show, B : Testable] small_check_error(
   expect? : Expected = Success,
   abort? : Bool = false,
 ) -> Unit raise Failure {
-  small_check(fn(a : A) { try? f(a) }, max_size~, expect~, abort~)
+  small_check((a : A) => try? f(a), max_size~, expect~, abort~)
 }
 
 ///|
@@ -306,7 +306,7 @@ pub fn[A : @feat.Enumerable + Show, B : Testable] small_check_error_silence(
   expect? : Expected = Success,
   abort? : Bool = false,
 ) -> String {
-  small_check_silence(fn(a : A) { try? f(a) }, max_size~, expect~, abort~)
+  small_check_silence((a : A) => try? f(a), max_size~, expect~, abort~)
 }
 
 ///|

--- a/src/falsify/driver.mbt
+++ b/src/falsify/driver.mbt
@@ -174,9 +174,7 @@ pub fn[T, E] falsify(
             ((e, run), shrunk),
           )
           // Correctly accessing tuple second element
-          let explain = sf
-            .e_fmap(fn(t) { t.1 })
-            .limit_steps(Some(opt.max_shrinks))
+          let explain = sf.e_fmap(t => t.1).limit_steps(Some(opt.max_shrinks))
           let failure = { seed: acc.rng.clone(), run: explain }
           (acc.success, acc.total_discard, Some(failure))
         }

--- a/src/falsify/gen.mbt
+++ b/src/falsify/gen.mbt
@@ -33,7 +33,7 @@ pub fn[T] Gen::run_gen(self : Gen[T], x : SampleTree) -> (T, Iter[SampleTree]) {
 /// Functor `fmap`: transform the generated value without touching the
 /// shrink set. Shrinks go through unchanged.
 pub fn[T, U] Gen::fmap(self : Gen[T], f : (T) -> U) -> Gen[U] {
-  new(fn(x) {
+  new(x => {
     let (v, rest) = self.run_gen(x)
     (f(v), rest)
   })
@@ -42,7 +42,7 @@ pub fn[T, U] Gen::fmap(self : Gen[T], f : (T) -> U) -> Gen[U] {
 ///|
 /// The constant generator: always yields `v`, never shrinks.
 pub fn[T] pure(v : T) -> Gen[T] {
-  new(fn(_x) { (v, Iter::empty()) })
+  new(_x => (v, Iter::empty()))
 }
 
 ///|
@@ -78,11 +78,11 @@ pub fn combine_shrunk(
   }
 
   unless_minimal(l, ls)
-  .map(fn(l1) {
+  .map(l1 => {
     SampleTree(s, @lazy.LazyRef::from_value(l1), @lazy.LazyRef::from_value(r))
   })
   .concat(
-    unless_minimal(r, rs).map(fn(_r1) {
+    unless_minimal(r, rs).map(_r1 => {
       SampleTree(s, @lazy.LazyRef::from_value(l), @lazy.LazyRef::from_value(r))
     }),
   )
@@ -95,7 +95,7 @@ pub fn combine_shrunk(
 /// stage draws from an independent sub-tree, and the returned shrink
 /// set is composed with `combine_shrunk`.
 pub fn[T, U] Gen::bind(self : Gen[T], f : (T) -> Gen[U]) -> Gen[U] {
-  new(fn(st) {
+  new(st => {
     let (s, l, r) = st.view()
     let (a, ls) = self.run_gen(l)
     let (b, rs) = f(a).run_gen(r)
@@ -108,7 +108,7 @@ pub fn[T, U] Gen::bind(self : Gen[T], f : (T) -> Gen[U]) -> Gen[U] {
 /// `bind` under the hood, so it inherits the same sample-tree
 /// splitting and shrink composition.
 pub fn[T, U] Gen::ap(self : Gen[(T) -> U], g : Gen[T]) -> Gen[U] {
-  self.bind(fn(f) { g.bind(fn(x) { pure(f(x)) }) })
+  self.bind(f => g.bind(x => pure(f(x))))
 }
 
 ///|
@@ -117,11 +117,11 @@ pub fn[T, U] Gen::ap(self : Gen[(T) -> U], g : Gen[T]) -> Gen[U] {
 /// those get wrapped in `Shrunk(u)` sub-trees so the driver can
 /// distinguish them from the original draw.
 pub fn prim_with(f : (Sample) -> Iter[UInt]) -> Gen[Sample] {
-  new(fn(x) {
+  new(x => {
     let (s, l, r) = x.view()
     (
       s,
-      f(s).map(fn(s1) {
+      f(s).map(s1 => {
         SampleTree(
           Shrunk(s1),
           @lazy.LazyRef::from_value(l),
@@ -137,5 +137,5 @@ pub fn prim_with(f : (Sample) -> Iter[UInt]) -> Gen[Sample] {
 /// of the sample tree and expose the standard "binary towards zero"
 /// shrink sequence.
 pub fn prim() -> Gen[UInt] {
-  prim_with(fn(s) { s.sample_value() |> binary() }).fmap(Sample::sample_value)
+  prim_with(s => s.sample_value() |> binary()).fmap(Sample::sample_value)
 }

--- a/src/falsify/property.mbt
+++ b/src/falsify/property.mbt
@@ -94,16 +94,14 @@ pub fn[T, E] run_property(
 /// driver to try another. Useful inside `bind` where a precondition
 /// doesn't hold.
 pub fn[T, E] discard() -> Property[T, E] {
-  mk_property(fn(run) { pure((TestDiscarded, run)) })
+  mk_property(run => pure((TestDiscarded, run)))
 }
 
 ///|
 /// Emit a diagnostic message to the run log. The property still
 /// "passes" at this step — `info` is orthogonal to the verdict.
 pub fn info(msg : String) -> Property[Unit, String] {
-  mk_property(fn(run) {
-    pure((TestPassed(()), { ..run, log: run.log.add(msg) }))
-  })
+  mk_property(run => pure((TestPassed(()), { ..run, log: run.log.add(msg) })))
 }
 
 ///|
@@ -118,7 +116,7 @@ pub fn[E] label(label : String, vals : List[String]) -> Property[Unit, E] {
     s.union(@sorted_set.from_iter(vals.iter()))
   }
 
-  mk_property(fn(r) {
+  mk_property(r => {
     let set = r.labels.get(label)
     pure(
       (TestPassed(()), { ..r, labels: r.labels.add(label, add_values(set)) }),
@@ -143,7 +141,7 @@ pub fn[T : Show, E] collect(l : String, ls : List[T]) -> Property[Unit, E] {
 /// `msg` to the run log.
 pub fn[T, E] gen(f : (T) -> String?, g : Gen[T]) -> Property[T, E] {
   fn aux(run : TestRun) -> (T) -> (TestResult[T, E], TestRun) {
-    fn(x) {
+    x => {
       match f(x) {
         None => (TestPassed(x), { ..run, deterministic: false })
         Some(msg) => (TestPassed(x), { ..run, log: run.log.add(msg) })
@@ -151,7 +149,7 @@ pub fn[T, E] gen(f : (T) -> String?, g : Gen[T]) -> Property[T, E] {
     }
   }
 
-  mk_property(fn(run) { g.fmap(aux(run)) })
+  mk_property(run => g.fmap(aux(run)))
 }
 
 ///|
@@ -160,7 +158,7 @@ pub fn[T, E] gen(f : (T) -> String?, g : Gen[T]) -> Property[T, E] {
 /// otherwise. The quickest way to hand a generator to `falsify`.
 pub fn[T] test_gen(f : (T) -> Bool, gen : Gen[T]) -> Property[T, String] {
   fn aux(run : TestRun) {
-    fn(a) {
+    a => {
       (
         match f(a) {
           true => TestPassed(a)
@@ -171,5 +169,5 @@ pub fn[T] test_gen(f : (T) -> Bool, gen : Gen[T]) -> Property[T, String] {
     }
   }
 
-  { run: fn(r) { gen.fmap(aux(r)) } }
+  { run: r => gen.fmap(aux(r)) }
 }

--- a/src/falsify/sample.mbt
+++ b/src/falsify/sample.mbt
@@ -105,7 +105,7 @@ pub fn SampleTree::map(self : SampleTree, f : (UInt) -> UInt) -> SampleTree {
 /// Clamp every sample to `[0, u)` by taking it modulo `u`. Useful for
 /// turning an arbitrary sample tree into one that stays in range.
 pub fn SampleTree::mod(self : SampleTree, u : UInt) -> SampleTree {
-  self.map(fn(x) { x % u })
+  self.map(x => x % u)
 }
 
 ///|

--- a/src/falsify/selective.mbt
+++ b/src/falsify/selective.mbt
@@ -23,7 +23,7 @@ fn[L, R, S] Either::fmap(self : Either[L, R], f : (R) -> S) -> Either[L, S] {
 /// Reference: Andrey Mokhov et al., _Selective applicative functors_,
 /// ICFP 2019. DOI 10.1145/3342521.
 pub fn[T, U] Gen::select(self : Gen[(T) -> U], e : Gen[Either[T, U]]) -> Gen[U] {
-  new(fn(st) {
+  new(st => {
     let (s, l, r) = st.view()
     let (ma, ls) = e.run_gen(l)
     match ma {
@@ -46,8 +46,8 @@ pub fn[A, B, C] Gen::branch(
   l : Gen[(A) -> C],
   r : Gen[(B) -> C],
 ) -> Gen[C] {
-  let left = self.fmap(fn(x) { x.fmap(fn(v) { Either::Left(v) }) })
-  let right = l.fmap(fn(g) { fn(x) { Right(g(x)) } })
+  let left = self.fmap(x => x.fmap(v => Either::Left(v)))
+  let right = l.fmap(g => x => Right(g(x)))
   r.select(right.select(left))
 }
 
@@ -56,9 +56,9 @@ pub fn[A, B, C] Gen::branch(
 /// if it was `false`. Only the chosen branch's sample tree is
 /// considered during shrinking.
 pub fn[T] Gen::ifS(self : Gen[Bool], t : Gen[T], e : Gen[T]) -> Gen[T] {
-  let const_ = fn(x) { fn(_y : Unit) { x } }
+  let const_ = x => (_y : Unit) => x
   self
-  .fmap(fn(x) { if x { Left(()) } else { Right(()) } })
+  .fmap(x => if x { Left(()) } else { Right(()) })
   .branch(t.fmap(const_), e.fmap(const_))
 }
 
@@ -67,5 +67,5 @@ pub fn[T] Gen::ifS(self : Gen[Bool], t : Gen[T], e : Gen[T]) -> Gen[T] {
 /// `select`, so it participates in the same "only shrink the branch
 /// that influenced the result" optimisation.
 pub fn[A, B] Gen::apS(self : Gen[(A) -> B], x : Gen[A]) -> Gen[B] {
-  x.fmap(fn(y) { fn(g) { g(y) } }).select(self.fmap(fn(v) { Left(v) }))
+  x.fmap(y => g => g(y)).select(self.fmap(v => Left(v)))
 }

--- a/src/falsify/shrinking.mbt
+++ b/src/falsify/shrinking.mbt
@@ -113,7 +113,7 @@ enum IsValidShrink[P, N] {
 
 ///|
 fn[A, B, C] either(f : (A) -> C, g : (B) -> C) -> (Result[A, B]) -> C {
-  fn(result : Result[A, B]) -> C {
+  (result : Result[A, B]) => {
     match result {
       Ok(x) => f(x)
       Err(y) => g(y)
@@ -126,14 +126,14 @@ fn[A, B, C] either(f : (A) -> C, g : (B) -> C) -> (Result[A, B]) -> C {
 ///|
 fn[T, E] partition_result(val : Iter[Result[T, E]]) -> (Iter[T], Iter[E]) {
   fn left(a : T) -> ((Iter[T], Iter[E])) -> (Iter[T], Iter[E]) {
-    fn(p) {
+    p => {
       let (l, r) = p
       (Iter::concat(Iter::singleton(a), l), r)
     }
   }
 
   fn right(a : E) -> ((Iter[T], Iter[E])) -> (Iter[T], Iter[E]) {
-    fn(p) {
+    p => {
       let (l, r) = p
       (l, Iter::concat(Iter::singleton(a), r))
     }
@@ -142,7 +142,7 @@ fn[T, E] partition_result(val : Iter[Result[T, E]]) -> (Iter[T], Iter[E]) {
   let r = either(left, right)
   Iter::fold(
     val,
-    fn(acc, item) { r(item)(acc) },
+    (acc, item) => r(item)(acc),
     init=(Iter::empty(), Iter::empty()),
   )
 }
@@ -171,7 +171,7 @@ pub fn[A, P, N] Gen::shrink_from(
   }
 
   fn go(shrunk : Iter[SampleTree]) -> ShrinkHistory[P, N] {
-    let candidates = shrunk.map(fn(x) { self.run_gen(x) |> consider })
+    let candidates = shrunk.map(x => self.run_gen(x) |> consider)
     let res = partition_result(candidates)
     match res.0.head() {
       None => ShrinkDone(res.1)
@@ -192,14 +192,14 @@ pub fn[A, P, N] Gen::shrink_from(
 /// `Shrunk(i)` path. Stick to `prim` / `pure` / `bind` if you need
 /// full coverage.
 pub fn[T] shrink_to_list(val : T, xs : Iter[T]) -> Gen[T] {
-  let shrinker = fn(s) {
+  let shrinker = s => {
     match s {
       Shrunk(_) => Iter::empty()
       NotShrunk(_) => abort("todo")
-      // @lazy.zip_with(fn(x, _y) { x }, @lazy.infinite_stream(0U, 1), xs)
+      // @lazy.zip_with((x, _y) => x, @lazy.infinite_stream(0U, 1), xs)
     }
   }
-  let aux = fn(s) {
+  let aux = s => {
     match s {
       NotShrunk(_) => val
       Shrunk(i) => xs.drop(i.reinterpret_as_int()).head().unwrap()

--- a/src/feat/README.mbt.md
+++ b/src/feat/README.mbt.md
@@ -85,7 +85,7 @@ write one directly:
 test "hand-rolled finite chunk" {
   let f : @feat.Finite[String] = {
     fCard: 2,
-    fIndex: fn(i) {
+    fIndex: i => {
       if i == 0 {
         "left"
       } else {
@@ -130,7 +130,7 @@ materialising the full list via `to_array`:
 ///|
 test "for x in finite" {
   let acc : Array[BigInt] = []
-  let finite : @feat.Finite[BigInt] = { fCard: 4, fIndex: fn(i) { i } }
+  let finite : @feat.Finite[BigInt] = { fCard: 4, fIndex: i => i }
   for x in finite {
     acc.push(x)
   }
@@ -167,7 +167,7 @@ test "singleton has size 0" {
 test "pay shifts everything one size up" {
   // Before pay: part₀ = {42}
   // After pay:  part₀ = {}, part₁ = {42}
-  let shifted = @feat.pay(fn() { @feat.singleton(42) })
+  let shifted = @feat.pay(() => @feat.singleton(42))
   let parts = shifted.eval()
   inspect(parts.head().to_array(), content="(0, @list.from_array([]))")
   inspect(parts.tail().head().to_array(), content="(1, @list.from_array([42]))")
@@ -305,7 +305,7 @@ test "enumerate the first few binary trees" {
 
 | Pitfall | Why it hurts | Fix |
 |---------|--------------|-----|
-| Unguarded self-reference: `T::enumerate()` called without a surrounding `pay`. | Recursion diverges (contract #2). | Wrap the body in `@feat.pay(fn() { ... })`. Going through `unary` + the pair instance achieves the same because the built-in `(A, B)` instance inserts its own `pay`. |
+| Unguarded self-reference: `T::enumerate()` called without a surrounding `pay`. | Recursion diverges (contract #2). | Wrap the body in `@feat.pay(() => ...)`. Going through `unary` + the pair instance achieves the same because the built-in `(A, B)` instance inserts its own `pay`. |
 | Computing a large Cartesian product with `product` before unioning. | Not wrong, just slow — the resulting parts get large and indexing locality suffers. | Prefer `unary` for a single-pair constructor, or `consts([...])` for a disjunction — these keep the structure flat. |
 | Mixing eager `List` of `Enumerate` with `consts` at the top of a recursive definition. | The `List` itself is eager: its elements are forced when the `consts` is reached, which can run into the recursion before `pay` kicks in. | Ensure the `consts(...)` is inside `pay`, or use `+` between lazy `Enumerate`s. |
 | Forgetting that zero-cardinality parts short-circuit. | Empty parts are skipped cheaply, but a hand-rolled `Finite` with a bogus non-zero `fCard` will still be indexed. | If you need an empty part, set `fCard: 0` and use an aborting `fIndex`. |
@@ -377,7 +377,7 @@ size-aware Cartesian `product`:
 | `Enumerate::fmap(e, f)` | `Enumerate[T] -> (T -> U) -> Enumerate[U]` | Re-label every element |
 | `e1 + e2` | `Enumerate[T] -> Enumerate[T] -> Enumerate[T]` | Interleave by size |
 | `product(e1, e2)` | `Enumerate[A] -> Enumerate[B] -> Enumerate[(A, B)]` | Pair every A with every B, still size-indexed |
-| `pay(fn() { … })` | `(() -> Enumerate[T]) -> Enumerate[T]` | Charge 1 unit of size |
+| `pay(() => …)` | `(() -> Enumerate[T]) -> Enumerate[T]` | Charge 1 unit of size |
 | `unary(f)` | `(T -> U) -> Enumerate[U]` where `T : Enumerable` | Shortcut for `T::enumerate().fmap(f)` |
 
 ```mbt check
@@ -400,12 +400,7 @@ test "product generates every pair in part order" {
 
 ///|
 fn zero_or_one_part() -> @feat.Enumerate[BigInt] {
-  {
-    parts: Cons(
-      { fCard: 2, fIndex: fn(i) { i } },
-      @lazy.LazyRef::from_value(Nil),
-    ),
-  }
+  { parts: Cons({ fCard: 2, fIndex: i => i }, @lazy.LazyRef::from_value(Nil)) }
 }
 ```
 

--- a/src/feat/enumerable.mbt
+++ b/src/feat/enumerable.mbt
@@ -16,7 +16,7 @@ pub(open) trait Enumerable {
 
 ///|
 pub impl Enumerable for Bool with enumerate() {
-  pay(fn() { singleton(true) + singleton(false) })
+  pay(() => singleton(true) + singleton(false))
 }
 
 ///|
@@ -26,20 +26,17 @@ pub impl Enumerable for Int with enumerate() {
   letrec int_parts_from: (Int) -> @lazy.LazyList[Finite[Int]] = n => {
     Cons(
       fin_pure(n),
-      @lazy.LazyRef::from_thunk(fn() {
+      @lazy.LazyRef::from_thunk(() => {
         Cons(
           fin_pure(-n),
-          @lazy.LazyRef::from_thunk(fn() { int_parts_from(n + 1) }),
+          @lazy.LazyRef::from_thunk(() => int_parts_from(n + 1)),
         )
       }),
     )
   }
 
   {
-    parts: Cons(
-      fin_pure(0),
-      @lazy.LazyRef::from_thunk(fn() { int_parts_from(1) }),
-    ),
+    parts: Cons(fin_pure(0), @lazy.LazyRef::from_thunk(() => int_parts_from(1))),
   }
 }
 
@@ -48,10 +45,10 @@ pub impl Enumerable for Int64 with enumerate() {
   letrec int64_parts_from: (Int64) -> @lazy.LazyList[Finite[Int64]] = n => {
     Cons(
       fin_pure(n),
-      @lazy.LazyRef::from_thunk(fn() {
+      @lazy.LazyRef::from_thunk(() => {
         Cons(
           fin_pure(-n),
-          @lazy.LazyRef::from_thunk(fn() { int64_parts_from(n + 1) }),
+          @lazy.LazyRef::from_thunk(() => int64_parts_from(n + 1)),
         )
       }),
     )
@@ -60,19 +57,19 @@ pub impl Enumerable for Int64 with enumerate() {
   {
     parts: Cons(
       fin_pure(0L),
-      @lazy.LazyRef::from_thunk(fn() { int64_parts_from(1L) }),
+      @lazy.LazyRef::from_thunk(() => int64_parts_from(1L)),
     ),
   }
 }
 
 ///|
 pub impl Enumerable for UInt with enumerate() {
-  pay(fn() { singleton(0U) + Enumerable::enumerate().fmap(fn(x) { x + 1U }) })
+  pay(() => singleton(0U) + Enumerable::enumerate().fmap(x => x + 1U))
 }
 
 ///|
 pub impl Enumerable for UInt64 with enumerate() {
-  pay(fn() { singleton(0UL) + Enumerable::enumerate().fmap(fn(x) { x + 1UL }) })
+  pay(() => singleton(0UL) + Enumerable::enumerate().fmap(x => x + 1UL))
 }
 
 ///|
@@ -115,19 +112,17 @@ pub impl[E : Enumerable] Enumerable for @moonbitlang/core/list.List[E] with enum
 
 ///|
 pub impl[A : Enumerable, B : Enumerable] Enumerable for (A, B) with enumerate() {
-  pay(fn() { product(A::enumerate(), B::enumerate()) })
+  pay(() => product(A::enumerate(), B::enumerate()))
 }
 
 ///|
 pub impl[E : Enumerable] Enumerable for E? with enumerate() {
-  pay(fn() { singleton(None) + E::enumerate().fmap(x => Some(x)) })
+  pay(() => singleton(None) + E::enumerate().fmap(x => Some(x)))
 }
 
 ///|
 pub impl[T : Enumerable, E : Enumerable] Enumerable for Result[T, E] with enumerate() {
-  pay(fn() {
-    E::enumerate().fmap(x => Err(x)) + T::enumerate().fmap(x => Ok(x))
-  })
+  pay(() => E::enumerate().fmap(x => Err(x)) + T::enumerate().fmap(x => Ok(x)))
 }
 
 ///|

--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -101,7 +101,7 @@ pub impl[T] Add for Enumerate[T] with add(self, other) {
 /// Rewrite every element without changing the structure: part shapes
 /// stay the same, only the inhabitants are relabelled via `f`.
 pub fn[T, U] Enumerate::fmap(self : Enumerate[T], f : (T) -> U) -> Enumerate[U] {
-  { parts: self.parts.map(fn(x) { fin_fmap(f, x) }) }
+  { parts: self.parts.map(x => fin_fmap(f, x)) }
 }
 
 ///|
@@ -111,7 +111,7 @@ pub fn[T, U] Enumerate::fmap(self : Enumerate[T], f : (T) -> U) -> Enumerate[U] 
 /// recursive self-reference must be wrapped in `pay` or the fixpoint
 /// diverges.
 pub fn[T] pay(f : () -> Enumerate[T]) -> Enumerate[T] {
-  { parts: Cons(fin_empty(), @lazy.LazyRef::from_thunk(fn() { f().parts })) }
+  { parts: Cons(fin_empty(), @lazy.LazyRef::from_thunk(() => f().parts)) }
 }
 
 ///|
@@ -128,7 +128,7 @@ fn[T, U] prod_helper(
   xs : LazyList[Finite[T]],
   rys : LazyList[LazyList[Finite[U]]],
 ) -> LazyList[Finite[(T, U)]] {
-  rys.map(fn(y) { convolution(xs, y) })
+  rys.map(y => convolution(xs, y))
 }
 
 ///|
@@ -137,7 +137,7 @@ fn[T, U] prod_helper(
 /// with `consts`. The outer `pay` charges one size unit for the
 /// constructor tag.
 pub fn[T] consts(ls : @list.List[Enumerate[T]]) -> Enumerate[T] {
-  pay(fn() { ls.fold(union, init=empty()) })
+  pay(() => ls.fold(union, init=empty()))
 }
 
 ///|

--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -34,7 +34,7 @@ fn[T] fin_union(f1 : Finite[T], f2 : Finite[T]) -> Finite[T] {
   } else {
     {
       fCard: f1.fCard + f2.fCard,
-      fIndex: fn(i) {
+      fIndex: i => {
         if i < f1.fCard {
           (f1.fIndex)(i)
         } else {
@@ -56,7 +56,7 @@ pub impl[T] Add for Finite[T] with add(self, other) {
 ///|
 /// Map `f` over the indexer: same cardinality, each element rewritten.
 fn[T, U] fin_fmap(f : (T) -> U, f1 : Finite[T]) -> Finite[U] {
-  { fCard: f1.fCard, fIndex: fn(i) { f((f1.fIndex)(i)) } }
+  { fCard: f1.fCard, fIndex: i => f((f1.fIndex)(i)) }
 }
 
 ///|
@@ -65,7 +65,7 @@ fn[T, U] fin_fmap(f : (T) -> U, f1 : Finite[T]) -> Finite[U] {
 fn[T] fin_pure(x : T) -> Finite[T] {
   {
     fCard: 1,
-    fIndex: fn(i) {
+    fIndex: i => {
       guard i == 0 else { abort("index out of bounds") }
       x
     },
@@ -79,7 +79,7 @@ fn[T] fin_pure(x : T) -> Finite[T] {
 fn[T, U] fin_cart(f1 : Finite[T], f2 : Finite[U]) -> Finite[(T, U)] {
   {
     fCard: f1.fCard * f2.fCard,
-    fIndex: fn(i) {
+    fIndex: i => {
       let j = i / f2.fCard
       let k = i % f2.fCard
       ((f1.fIndex)(j), (f2.fIndex)(k))
@@ -89,7 +89,7 @@ fn[T, U] fin_cart(f1 : Finite[T], f2 : Finite[U]) -> Finite[(T, U)] {
 
 ///|
 fn[M] sum_sel(a : Array[Finite[M]]) -> (BigInt) -> M {
-  fn(idx) {
+  idx => {
     for j = 0, i = idx {
       if i < a[j].fCard || j >= a.length() {
         break (a[j].fIndex)(i)
@@ -105,8 +105,8 @@ fn[M] sum_sel(a : Array[Finite[M]]) -> (BigInt) -> M {
 /// filtered before indexing so the resulting selector skips them.
 fn[M] fin_concat(m : Array[Finite[M]]) -> Finite[M] {
   {
-    fCard: sum(m.map(fn(x) { x.fCard })),
-    fIndex: sum_sel(m.filter(fn(x) { x.fCard > 0 })),
+    fCard: sum(m.map(x => x.fCard)),
+    fIndex: sum_sel(m.filter(x => x.fCard > 0)),
   }
 }
 
@@ -176,7 +176,7 @@ test "iter is lazy — early break stops walking" {
   let calls = Ref::new(0)
   let probe : Finite[Int] = {
     fCard: 1000,
-    fIndex: fn(_i) {
+    fIndex: _i => {
       calls.val = calls.val + 1
       42
     },
@@ -218,7 +218,7 @@ fn fin_finite(i : BigInt) -> Finite[BigInt] {
   if i < 0 {
     fin_empty()
   } else {
-    { fCard: i, fIndex: fn(j) { j } }
+    { fCard: i, fIndex: j => j }
   }
 }
 

--- a/src/feat/utils.mbt
+++ b/src/feat/utils.mbt
@@ -26,7 +26,7 @@ fn[T] reversals(l : LazyList[T]) -> LazyList[LazyList[T]] {
         let rev1 = @lazy.Cons(x, rev)
         Cons(
           rev1,
-          @lazy.LazyRef::from_thunk(fn() {
+          @lazy.LazyRef::from_thunk(() => {
             go(@lazy.LazyRef::from_value(rev1), xs.force())
           }),
         )

--- a/src/internal/benchmark/bm-curry-forall-tuple.mbt
+++ b/src/internal/benchmark/bm-curry-forall-tuple.mbt
@@ -5,23 +5,21 @@ fn prop_symmetry(x : Array[Int], y : Array[Int]) -> Bool {
 }
 
 ///|
-let test_forall : @qc.Property = @qc.forall(@qc.Gen::spawn(), fn(
-  x : Array[Int],
-) {
-  @qc.forall(@qc.Gen::spawn(), fn(y : Array[Int]) { prop_symmetry(x, y) })
+let test_forall : @qc.Property = @qc.forall(@qc.Gen::spawn(), (x : Array[Int]) => {
+  @qc.forall(@qc.Gen::spawn(), (y : Array[Int]) => prop_symmetry(x, y))
 })
 
 ///|
 fn[A, B] coerce(x : A) -> B = "%identity"
 
 ///|
-let test_curry : @qc.Arrow[Array[Int], @qc.Arrow[Array[Int], Bool]] = (fn(a) {
-    fn(b) { prop_symmetry(a, b) }
+let test_curry : @qc.Arrow[Array[Int], @qc.Arrow[Array[Int], Bool]] = (a => {
+    b => prop_symmetry(a, b)
   })
   |> coerce
 
 ///|
-let test_tuple : @qc.Arrow[(Array[Int], Array[Int]), Bool] = (fn(p) {
+let test_tuple : @qc.Arrow[(Array[Int], Array[Int]), Bool] = (p => {
     let (x, y) = p
     prop_symmetry(x, y)
   })
@@ -29,15 +27,15 @@ let test_tuple : @qc.Arrow[(Array[Int], Array[Int]), Bool] = (fn(p) {
 
 ///|
 test (b : @bench.T) {
-  b.bench(name="forall", fn() { b.keep(try? @qc.quick_check(test_forall)) })
+  b.bench(name="forall", () => b.keep(try? @qc.quick_check(test_forall)))
 }
 
 ///|
 test (b : @bench.T) {
-  b.bench(name="curry", fn() { b.keep(try? @qc.quick_check(test_curry)) })
+  b.bench(name="curry", () => b.keep(try? @qc.quick_check(test_curry)))
 }
 
 ///|
 test (b : @bench.T) {
-  b.bench(name="tuple", fn() { b.keep(try? @qc.quick_check(test_tuple)) })
+  b.bench(name="tuple", () => b.keep(try? @qc.quick_check(test_tuple)))
 }

--- a/src/internal/lazy/lazy_list.mbt
+++ b/src/internal/lazy/lazy_list.mbt
@@ -104,7 +104,7 @@ pub fn[T] LazyList::tails(self : LazyList[T]) -> LazyList[LazyList[T]] {
       xs,
       match xs {
         Nil => LazyRef::from_value(Nil)
-        Cons(_, xs1) => LazyRef::from_thunk(fn() { go(xs1.force()) })
+        Cons(_, xs1) => LazyRef::from_thunk(() => go(xs1.force()))
       },
     )
   }
@@ -122,8 +122,7 @@ pub fn[T] LazyList::concat(
 ) -> LazyList[T] {
   match self {
     Nil => other
-    Cons(x, xs) =>
-      Cons(x, LazyRef::from_thunk(fn() { xs.force().concat(other) }))
+    Cons(x, xs) => Cons(x, LazyRef::from_thunk(() => xs.force().concat(other)))
   }
 }
 
@@ -136,7 +135,7 @@ pub impl[T] Add for LazyList[T] with add(self, other) {
 ///|
 /// An infinite stream of a single value: `[x, x, x, ...]`.
 pub fn[T] repeat(val : T) -> LazyList[T] {
-  Cons(val, LazyRef::from_thunk(fn() { repeat(val) }))
+  Cons(val, LazyRef::from_thunk(() => repeat(val)))
 }
 
 ///|
@@ -145,7 +144,7 @@ pub fn[T] repeat(val : T) -> LazyList[T] {
 pub fn[T, U] LazyList::map(self : LazyList[T], f : (T) -> U) -> LazyList[U] {
   match self {
     Nil => Nil
-    Cons(x, xs) => Cons(f(x), LazyRef::from_thunk(fn() { xs.force().map(f) }))
+    Cons(x, xs) => Cons(f(x), LazyRef::from_thunk(() => xs.force().map(f)))
   }
 }
 
@@ -233,7 +232,7 @@ pub fn[T] LazyList::tail(self : LazyList[T]) -> LazyList[T] {
 /// Number of elements. **Forces the entire list** — don't call on
 /// infinite input.
 pub fn[T] LazyList::length(self : LazyList[T]) -> Int {
-  self.fold_left(fn(acc, _x) { acc + 1 }, init=0)
+  self.fold_left((acc, _x) => acc + 1, init=0)
 }
 
 ///|
@@ -254,7 +253,7 @@ pub fn[A, B, C] zip_with(
     (Cons(x, xs), Cons(y, ys)) =>
       Cons(
         f(x, y),
-        LazyRef::from_thunk(fn() { zip_with(f, xs.force(), ys.force()) }),
+        LazyRef::from_thunk(() => zip_with(f, xs.force(), ys.force())),
       )
     (_, _) => Nil
   }
@@ -271,7 +270,7 @@ pub fn[T] LazyList::take_while(
     Nil => Nil
     Cons(x, xs) =>
       if p(x) {
-        Cons(x, LazyRef::from_thunk(fn() { xs.force().take_while(p) }))
+        Cons(x, LazyRef::from_thunk(() => xs.force().take_while(p)))
       } else {
         Nil
       }
@@ -287,8 +286,7 @@ pub fn[T] LazyList::take(self : LazyList[T], n : Int) -> LazyList[T] {
   } else {
     match self {
       Nil => Nil
-      Cons(x, xs) =>
-        Cons(x, LazyRef::from_thunk(fn() { xs.force().take(n - 1) }))
+      Cons(x, xs) => Cons(x, LazyRef::from_thunk(() => xs.force().take(n - 1)))
     }
   }
 }
@@ -334,7 +332,7 @@ pub fn[T] LazyList::drop_while(
 /// Infinite arithmetic progression: `[start, start + step, start + 2*step, ...]`.
 /// `X` must be `Add`-able. Lazy — consume via `take` / `take_while`.
 pub fn[X : Add] infinite_stream(start : X, step : X) -> LazyList[X] {
-  Cons(start, LazyRef::from_thunk(fn() { infinite_stream(start + step, step) }))
+  Cons(start, LazyRef::from_thunk(() => infinite_stream(start + step, step)))
 }
 
 ///|
@@ -369,7 +367,7 @@ pub fn[T] zip_plus(
     (Cons(x, xs), Cons(y, ys)) =>
       Cons(
         f(x, y),
-        LazyRef::from_thunk(fn() { zip_plus(f, xs.force(), ys.force()) }),
+        LazyRef::from_thunk(() => zip_plus(f, xs.force(), ys.force())),
       )
     (xs, ys) => xs.concat(ys)
   }
@@ -385,7 +383,7 @@ pub fn[T] LazyList::unfold(
 ) -> LazyList[T] {
   match f(self) {
     None => Nil
-    Some((x, y)) => Cons(x, LazyRef::from_thunk(fn() { y.unfold(f) }))
+    Some((x, y)) => Cons(x, LazyRef::from_thunk(() => y.unfold(f)))
   }
 }
 

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -39,7 +39,7 @@ pub fn[T] Rose::new(val : T, branch : Iter[Rose[T]]) -> Rose[T] {
 pub fn[T] Rose::join(self : Rose[Rose[T]]) -> Rose[T] {
   let tss = self.branch
   let ts = self.val.branch
-  { val: self.val.val, branch: tss.map(fn(x) { x.join() }).concat(ts) }
+  { val: self.val.val, branch: tss.map(x => x.join()).concat(ts) }
 }
 
 ///|
@@ -54,7 +54,7 @@ pub fn[T] pure(val : T) -> Rose[T] {
 /// result has the same shape as `self`, with each node's value
 /// replaced by `f(value)`.
 pub fn[T, U] Rose::fmap(self : Rose[T], f : (T) -> U) -> Rose[U] {
-  { val: f(self.val), branch: self.branch.map(fn(x) { x.fmap(f) }) }
+  { val: f(self.val), branch: self.branch.map(x => x.fmap(f)) }
 }
 
 ///|

--- a/src/internal/shrinking/shrink_tree.mbt
+++ b/src/internal/shrinking/shrink_tree.mbt
@@ -51,8 +51,8 @@ pub fn[T : Show] ShrinkTree::to_string_with_depth(
   }
   let s = self.leaf.to_string()
   let child = self.branch
-    .map(fn(x) { x.to_string_with_depth(depth - 1) })
-    .filter(fn(x) { x != "" })
+    .map(x => x.to_string_with_depth(depth - 1))
+    .filter(x => x != "")
     .collect()
     .join(", ")
   "Node(\{s}, [\{child}])"
@@ -80,14 +80,14 @@ pub fn[T, U] ShrinkTree::smap(
   self : ShrinkTree[T],
   f : (T) -> U,
 ) -> ShrinkTree[U] {
-  { leaf: self.leaf |> f, branch: self.branch.map(fn(x) { x.smap(f) }) }
+  { leaf: self.leaf |> f, branch: self.branch.map(x => x.smap(f)) }
 }
 
 ///|
 pub fn[T] ShrinkTree::join(self : ShrinkTree[ShrinkTree[T]]) -> ShrinkTree[T] {
   let x = self.leaf.leaf
   let ts = self.branch
-    .map(fn(x) { x.join() })
+    .map(x => x.join())
     .concat(
       match self.leaf {
         { branch: ts, .. } => ts

--- a/src/internal/testing/axiom.mbt
+++ b/src/internal/testing/axiom.mbt
@@ -117,7 +117,7 @@ test "queue front and dequeue" {
 test "queue roundtrip property" {
   inspect(
     @qc.quick_check_silence(
-      @qc.Arrow(fn(q : Queue) { q.to_list().rev().rev() == q.to_list() }),
+      @qc.Arrow((q : Queue) => q.to_list().rev().rev() == q.to_list()),
     ),
     content="+++ [100/0/100] Ok, passed!",
   )
@@ -125,7 +125,7 @@ test "queue roundtrip property" {
 
 ///|
 test "queue equivalence property" {
-  let prop_eq_queue = fn(eq : EqQueue) {
+  let prop_eq_queue = (eq : EqQueue) => {
     match eq {
       EqQueue(equiv) => {
         let lhs = equiv.lhs.to_list().length()

--- a/src/internal/testing/driver.mbt
+++ b/src/internal/testing/driver.mbt
@@ -20,7 +20,7 @@ fn prop_rev(l : List[Int]) -> Bool {
 
 ///|
 test "prop reverse (fail)" {
-  let prop_rev = fn(l : List[Int]) { l.rev().rev() == l.rev() }
+  let prop_rev = (l : List[Int]) => l.rev().rev() == l.rev()
   inspect(
     @qc.quick_check_silence(prop_rev |> @qc.Arrow, expect=Fail),
     content="+++ [9/0/100] Ok! Failed as expected.",
@@ -77,7 +77,7 @@ test "add assoc double (expect fail)" {
 
 ///|
 test "small check pass" {
-  let prop = fn(x : Int) { x + 0 == x }
+  let prop = (x : Int) => x + 0 == x
   inspect(
     @qc.small_check_silence(prop, max_size=1000000),
     content="+++ [1000000/0/1000000] Ok, passed!",
@@ -86,7 +86,7 @@ test "small check pass" {
 
 ///|
 test "small check expect fail" {
-  let prop = fn(x : Int) { x == 0 }
+  let prop = (x : Int) => x == 0
   inspect(
     @qc.small_check_silence(prop, max_size=5, expect=Fail),
     content="+++ [1/0/5] Ok! Failed as expected.",
@@ -95,7 +95,7 @@ test "small check expect fail" {
 
 ///|
 test "non empty list (with filter)" {
-  let prop_is_non_empty = fn(l : List[Int]) -> @qc.Property {
+  let prop_is_non_empty = (l : List[Int]) => {
     (!l.is_empty()) |> @qc.filter(!l.is_empty())
   }
   inspect(
@@ -106,7 +106,7 @@ test "non empty list (with filter)" {
 
 ///|
 test "reject all" {
-  let prop_reject = fn(_x : Int) { @qc.filter(true, false) }
+  let prop_reject = (_x : Int) => @qc.filter(true, false)
   inspect(
     @qc.quick_check_silence(@qc.Arrow(prop_reject), expect=GaveUp),
     content="+++ [0/1000/100] Ok, gave up!",
@@ -118,7 +118,7 @@ test "label" {
   let ar : @qc.Arrow[List[Int], Bool] = Arrow(prop_rev)
   inspect(
     @qc.quick_check_silence(
-      @qc.Arrow(fn(x : List[Int]) {
+      @qc.Arrow((x : List[Int]) => {
         @qc.label(ar, if x.is_empty() { "trivial" } else { "non-trivial" })
       }),
     ),
@@ -148,7 +148,7 @@ test "nested arrow uses fresh sample" {
 test "classes" {
   inspect(
     @qc.quick_check_silence(
-      @qc.Arrow(fn(x : List[Int]) {
+      @qc.Arrow((x : List[Int]) => {
         prop_rev(x)
         |> @qc.classify(x.length() > 5, "long list")
         |> @qc.classify(x.length() <= 5, "short list")
@@ -264,9 +264,8 @@ impl Show for Nat with output(self, logger) {
 
 ///|
 impl @feat.Enumerable for Nat with enumerate() {
-  @feat.pay(fn() {
-    @feat.singleton(Zero) +
-    @feat.Enumerable::enumerate().fmap(fn(n) { Succ(n) })
+  @feat.pay(() => {
+    @feat.singleton(Zero) + @feat.Enumerable::enumerate().fmap(n => Succ(n))
   })
 }
 
@@ -378,7 +377,7 @@ test "prop remove not presence with max success" {
 test "custom generator" {
   inspect(
     @qc.quick_check_silence(
-      @qc.forall(@qc.Gen::spawn(), fn(i_arr : (Int, Array[Int])) {
+      @qc.forall(@qc.Gen::spawn(), (i_arr : (Int, Array[Int])) => {
         let (x, arr) = i_arr
         !remove(arr, x).contains(x)
       }),
@@ -396,7 +395,7 @@ test "no_duplicate" {
 
   inspect(
     @qc.quick_check_silence(
-      @qc.forall(@qc.Gen::spawn(), fn(iarr : (Int, Array[Int])) {
+      @qc.forall(@qc.Gen::spawn(), (iarr : (Int, Array[Int])) => {
         let (x, arr) = iarr
         (!remove(arr.copy(), x).contains(x)) |> @qc.filter(no_duplicate(arr))
       }),
@@ -410,10 +409,8 @@ test "no_duplicate" {
 test "use one_of" {
   inspect(
     @qc.quick_check_silence(
-      @qc.forall(@qc.Gen::spawn(), fn(a : Array[Int]) {
-        @qc.forall(@qc.one_of_array(a), fn(y : Int) {
-          !remove(a, y).contains(y)
-        })
+      @qc.forall(@qc.Gen::spawn(), (a : Array[Int]) => {
+        @qc.forall(@qc.one_of_array(a), (y : Int) => !remove(a, y).contains(y))
         |> @qc.filter(a.length() != 0)
       }),
       expect=Fail,
@@ -426,7 +423,7 @@ test "use one_of" {
 test "explicit universal qualification" {
   inspect(
     @qc.quick_check_silence(
-      @qc.forall(@qc.Gen::spawn(), fn(x : List[Int]) { x.rev().rev() == x }),
+      @qc.forall(@qc.Gen::spawn(), (x : List[Int]) => x.rev().rev() == x),
     ),
     content="+++ [100/0/100] Ok, passed!",
   )

--- a/src/internal/testing/gen.mbt
+++ b/src/internal/testing/gen.mbt
@@ -79,7 +79,7 @@ test "backtrack ignores zero-weight candidate" {
 ///|
 test "sized trivial" {
   let gen : @qc.Gen[Int] = @qc.sized(@qc.pure)
-  let arr = Array::makei(10, fn(i) { gen.sample(size=i) })
+  let arr = Array::makei(10, i => gen.sample(size=i))
   inspect(arr, content="[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]")
 }
 

--- a/src/internal/testing/tutorial_en/README.mbt.md
+++ b/src/internal/testing/tutorial_en/README.mbt.md
@@ -532,7 +532,7 @@ QuickCheck defines default test data generators and shrinkers for some often use
 using @list {type List}
 
 ///|
-let prop_rev : (List[Int]) -> Bool = fn(x : List[Int]) { x.rev().rev() == x }
+let prop_rev : (List[Int]) -> Bool = (x : List[Int]) => x.rev().rev() == x
 
 ///|
 test "List reverse" {
@@ -593,7 +593,7 @@ test {
   }
 
   @qc.quick_check(
-    @qc.forall(@qc.Gen::spawn(), fn(iarr : (Int, Array[Int])) {
+    @qc.forall(@qc.Gen::spawn(), (iarr : (Int, Array[Int])) => {
       let (x, arr) = iarr
       @qc.filter(!remove(arr.copy(), x).contains(x), no_duplicate(arr))
     }),
@@ -640,7 +640,7 @@ The `label` function takes a string and classifies the test case with the string
 ```mbt check
 ///|
 test "label" {
-  @qc.quick_check_fn(fn(x : List[Int]) {
+  @qc.quick_check_fn((x : List[Int]) => {
     prop_rev(x)
     |> @qc.label(if x.is_empty() { "trivial" } else { "non-trivial" })
   })

--- a/src/internal/testing/tutorial_en/Tutorial1.mbt.md
+++ b/src/internal/testing/tutorial_en/Tutorial1.mbt.md
@@ -267,7 +267,7 @@ A very naive testing strategy is to implement `Queue` and test these axioms dire
 ///|
 /// `gen_queue()` is a generator that produces random Queue instances
 test "property Q2" {
-  let prop = @qc.forall(@qc.tuple(@qc.small_int(), gen_queue()), fn(p) {
+  let prop = @qc.forall(@qc.tuple(@qc.small_int(), gen_queue()), p => {
     let (x, q) = p
     q.enqueue(x).is_empty() == false
   })
@@ -544,7 +544,7 @@ fn[T : Eq] ModelSet::insert(self : ModelSet[T], x : T) -> ModelSet[T] {
 
 ///|
 fn[T : Eq] ModelSet::remove(self : ModelSet[T], x : T) -> ModelSet[T] {
-  ModelSet(self.0.filter(fn(y) { y != x }))
+  ModelSet(self.0.filter(y => y != x))
 }
 ```
 
@@ -622,7 +622,7 @@ pub fn run_sut(cmds : @list.List[Cmd]) -> (SUTSet[Int], Trace) {
 ///|
 test "model-based testing for Set" {
   let gen = @qc.Gen::spawn().list_with_size(20)
-  let prop = @qc.forall(gen, fn(cmds) {
+  let prop = @qc.forall(gen, cmds => {
     let (model_set, model_trace) = run_model(cmds)
     let (sut_set, sut_trace) = run_sut(cmds)
     let model_set_arr = model_set.0.sort()

--- a/src/internal/testing/tutorial_en/Tutorial2.mbt.md
+++ b/src/internal/testing/tutorial_en/Tutorial2.mbt.md
@@ -111,7 +111,7 @@ Multi-argument functions are the norm in real systems. `@qc.tuple`, `@qc.triple`
 ///|
 test "gen @qc.tuple for two args" {
   let gen = @qc.tuple(@qc.int_range(-20, 20), @qc.int_range(-20, 20))
-  let prop = @qc.forall(gen, fn(p) {
+  let prop = @qc.forall(gen, p => {
     let (a, b) = p
     a - b + b == a
   })

--- a/src/internal/testing/tutorial_en/Tutorial3.mbt.md
+++ b/src/internal/testing/tutorial_en/Tutorial3.mbt.md
@@ -299,7 +299,7 @@ Consider a mild example. Suppose we only want to test non-empty lists, so we add
 ```mbt check
 ///|
 test "discard on non-empty lists" {
-  let prop_non_empty = fn(xs : @list.List[Int]) -> @qc.Property {
+  let prop_non_empty = (xs : @list.List[Int]) => {
     (!xs.is_empty()) |> @qc.filter(!xs.is_empty())
   }
   inspect(
@@ -316,7 +316,7 @@ In the extreme case, the test may give up entirely:
 ```mbt check
 ///|
 test "reject all gives up" {
-  let prop_reject = fn(_x : Int) { @qc.filter(true, false) }
+  let prop_reject = (_x : Int) => @qc.filter(true, false)
   inspect(
     @qc.quick_check_silence(@qc.Arrow(prop_reject), expect=GaveUp),
     content="+++ [0/1000/100] Ok, gave up!",
@@ -438,7 +438,7 @@ Once the enumerator is in place, using SmallCheck is straightforward. We decide 
 ```mbt check
 ///|
 test "small check on peano prefix" {
-  let r = @qc.small_check_silence(fn(n : PeanoNat) { n == PZero }, max_size=5)
+  let r = @qc.small_check_silence((n : PeanoNat) => n == PZero, max_size=5)
   inspect(
     r,
     content=(

--- a/src/internal/testing/tutorial_zh/Tutorial1.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial1.mbt.md
@@ -83,7 +83,7 @@ test "@qc.tuple property" {
 ///|
 test "@qc.forall with @qc.int_range" {
   let gen = @qc.int_range(-10, 10)
-  let prop = @qc.forall(gen, fn(x) { x + 1 > x })
+  let prop = @qc.forall(gen, x => x + 1 > x)
   @qc.quick_check(prop)
 }
 ```
@@ -117,7 +117,7 @@ test "peek generator" {
 ```mbt check
 ///|
 test "@qc.quick_check_silence" {
-  let prop = @qc.forall(@qc.int_range(0, 5), fn(x) { x >= 0 })
+  let prop = @qc.forall(@qc.int_range(0, 5), x => x >= 0)
   inspect(@qc.quick_check_silence(prop), content="+++ [100/0/100] Ok, passed!")
 }
 ```
@@ -148,7 +148,7 @@ QuickCheck 并不要求我们先理解复杂的缩减细节，而是提供了一
 ///|
 test "@laws.commutative for add" {
   let gen = @qc.tuple(@qc.int_range(-200, 200), @qc.int_range(-200, 200))
-  let prop = @qc.forall(gen, @laws.commutative(fn(a, b) { a + b }))
+  let prop = @qc.forall(gen, @laws.commutative((a, b) => a + b))
   @qc.quick_check(prop)
 }
 ```
@@ -312,7 +312,7 @@ declare fn dequeue(q : Queue) -> Queue
 ///|
 /// `gen_queue()` 是一个生成随机 Queue 实例的生成器
 test "property Q2" {
-  let prop = @qc.forall(@qc.tuple(@qc.small_int(), gen_queue()), fn(p) {
+  let prop = @qc.forall(@qc.tuple(@qc.small_int(), gen_queue()), p => {
     let (x, q) = p
     is_empty(enqueue(x, q)) == false
   })
@@ -429,13 +429,13 @@ fn q6(xq : (Int, Queue)) -> Bool {
 ```mbt check
 ///|
 fn gen_int_list() -> @qc.Gen[@list.List[Int]] {
-  @qc.sized(fn(n) { @qc.small_int().list_with_size(n) })
+  @qc.sized(n => @qc.small_int().list_with_size(n))
 }
 
 ///|
 fn gen_queue() -> @qc.Gen[Queue] {
   let gl = gen_int_list()
-  gl.bind(fn(f) { gl.bind(fn(r) { @qc.pure(bq(f, r)) }) })
+  gl.bind(f => gl.bind(r => @qc.pure(bq(f, r))))
 }
 
 ///|
@@ -473,7 +473,7 @@ test "queue axioms q1-q6" {
 fn from_list(xs : @list.List[Int]) -> @qc.Gen[Queue] {
   let len = xs.length()
   let gen_i = if len <= 0 { @qc.pure(0) } else { @qc.int_range(0, len + 1) }
-  gen_i.fmap(fn(i) {
+  gen_i.fmap(i => {
     let xs1 = xs.take(i)
     let xs2 = xs.drop(i)
     bq(xs1, xs2.rev())
@@ -482,8 +482,8 @@ fn from_list(xs : @list.List[Int]) -> @qc.Gen[Queue] {
 
 ///|
 fn gen_equiv_queue() -> @qc.Gen[@laws.Equivalence[Queue]] {
-  gen_int_list().bind(fn(z) {
-    from_list(z).bind(fn(x) { from_list(z).fmap(fn(y) { { lhs: x, rhs: y } }) })
+  gen_int_list().bind(z => {
+    from_list(z).bind(x => from_list(z).fmap(y => { lhs: x, rhs: y }))
   })
 }
 
@@ -622,7 +622,7 @@ fn[T : Eq] ModelSet::insert(self : ModelSet[T], x : T) -> ModelSet[T] {
 
 ///|
 fn[T : Eq] ModelSet::remove(self : ModelSet[T], x : T) -> ModelSet[T] {
-  ModelSet(self.0.filter(fn(y) { y != x }))
+  ModelSet(self.0.filter(y => y != x))
 }
 ```
 
@@ -696,7 +696,7 @@ pub fn run_sut(cmds : @list.List[Cmd]) -> (SUTSet[Int], Trace) {
 ///|
 test "model-based testing for Set" {
   let gen = @qc.Gen::spawn().list_with_size(20)
-  let prop = @qc.forall(gen, fn(cmds) {
+  let prop = @qc.forall(gen, cmds => {
     let (model_set, model_trace) = run_model(cmds)
     let (sut_set, sut_trace) = run_sut(cmds)
     let model_set_arr = model_set.0.sort()

--- a/src/internal/testing/tutorial_zh/Tutorial2.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial2.mbt.md
@@ -43,7 +43,7 @@ $$
 ///|
 test "gen @qc.int_range invariant" {
   let gen = @qc.int_range(-10, 10)
-  let prop = @qc.forall(gen, fn(x) { x >= -10 && x <= 10 })
+  let prop = @qc.forall(gen, x => x >= -10 && x <= 10)
   @qc.quick_check(prop)
 }
 ```
@@ -55,7 +55,7 @@ test "gen @qc.int_range invariant" {
 ///|
 test "gen @qc.pure value" {
   let gen = @qc.pure(7)
-  let prop = @qc.forall(gen, fn(x) { x == 7 })
+  let prop = @qc.forall(gen, x => x == 7)
   @qc.quick_check(prop)
 }
 ```
@@ -145,7 +145,7 @@ test "gen @qc.list_with_size sample" {
 ///|
 test "gen @qc.tuple for two args" {
   let gen = @qc.tuple(@qc.int_range(-20, 20), @qc.int_range(-20, 20))
-  let prop = @qc.forall(gen, fn(p) {
+  let prop = @qc.forall(gen, p => {
     let (a, b) = p
     a - b + b == a
   })
@@ -160,8 +160,8 @@ test "gen @qc.tuple for two args" {
 ```mbt check
 ///|
 test "gen fmap transform" {
-  let gen = @qc.int_range(0, 50).fmap(fn(x) { x * 2 })
-  let prop = @qc.forall(gen, fn(x) { x % 2 == 0 })
+  let gen = @qc.int_range(0, 50).fmap(x => x * 2)
+  let prop = @qc.forall(gen, x => x % 2 == 0)
   @qc.quick_check(prop)
 }
 ```
@@ -184,7 +184,7 @@ test "gen fmap transform" {
 ///|
 test "gen @qc.one_of mix" {
   let gen = @qc.one_of([@qc.pure(0), @qc.pure(1), @qc.int_range(-10, 10)])
-  let prop = @qc.forall(gen, fn(x) { x >= -10 && x <= 10 })
+  let prop = @qc.forall(gen, x => x >= -10 && x <= 10)
   @qc.quick_check(prop)
 }
 ```
@@ -200,7 +200,7 @@ test "gen @qc.frequency weighted" {
     (6, @qc.int_range(-3, 3)),
     (1, @qc.int_range(-30, 30)),
   ])
-  let prop = @qc.forall(gen, fn(x) { x >= -30 && x <= 30 })
+  let prop = @qc.forall(gen, x => x >= -30 && x <= 30)
   @qc.quick_check(prop)
 }
 ```
@@ -214,7 +214,7 @@ test "gen @qc.frequency weighted" {
 test "gen @qc.one_of_array enum" {
   let methods : Array[String] = ["GET", "POST", "PUT"]
   let gen = @qc.one_of_array(methods)
-  let prop = @qc.forall(gen, fn(m) { methods.contains(m) })
+  let prop = @qc.forall(gen, m => methods.contains(m))
   @qc.quick_check(prop)
 }
 ```
@@ -228,10 +228,10 @@ test "gen @qc.one_of_array enum" {
 ```mbt check
 ///|
 test "gen bind dependent" {
-  let gen = @qc.int_range(-10, 10).bind(fn(base) {
-    @qc.int_range(0, 5).fmap(fn(delta) { (base, base + delta) })
+  let gen = @qc.int_range(-10, 10).bind(base => {
+    @qc.int_range(0, 5).fmap(delta => (base, base + delta))
   })
-  let prop = @qc.forall(gen, fn(p) {
+  let prop = @qc.forall(gen, p => {
     let (a, b) = p
     a <= b && b - a <= 5
   })
@@ -262,8 +262,8 @@ test "gen bind dependent" {
 ```mbt check
 ///|
 test "@qc.quick_check max_size" {
-  let gen = @qc.sized(fn(n) { @qc.small_int().list_with_size(n) })
-  let prop = @qc.forall(gen, fn(xs) { xs.length() >= 0 })
+  let gen = @qc.sized(n => @qc.small_int().list_with_size(n))
+  let prop = @qc.forall(gen, xs => xs.length() >= 0)
   @qc.quick_check(prop, max_size=30)
 }
 ```
@@ -275,7 +275,7 @@ test "@qc.quick_check max_size" {
 ```mbt check
 ///|
 test "@qc.sized array with explicit length" {
-  let gen = @qc.sized(fn(n) {
+  let gen = @qc.sized(n => {
     let len = if n < 0 { 0 } else { n }
     @qc.tuple(@qc.pure(len), @qc.int_range(0, 9).array_with_size(len))
   })
@@ -294,9 +294,9 @@ test "@qc.sized array with explicit length" {
 ```mbt check
 ///|
 test "resize clamps size" {
-  let gen = @qc.sized(fn(n) { @qc.int_range(0, 9).list_with_size(n) })
+  let gen = @qc.sized(n => @qc.int_range(0, 9).list_with_size(n))
   let small = gen.resize(5)
-  let prop = @qc.forall(small, fn(xs) { xs.length() == 5 })
+  let prop = @qc.forall(small, xs => xs.length() == 5)
   @qc.quick_check(prop)
 }
 ```
@@ -308,9 +308,9 @@ test "resize clamps size" {
 ```mbt check
 ///|
 test "scale slows growth" {
-  let gen = @qc.sized(fn(n) { @qc.int_range(0, 9).list_with_size(n) })
-  let scaled = gen.scale(fn(n) { n / 2 })
-  let prop = @qc.forall(scaled, fn(xs) { xs.length() <= 20 })
+  let gen = @qc.sized(n => @qc.int_range(0, 9).list_with_size(n))
+  let scaled = gen.scale(n => n / 2)
+  let prop = @qc.forall(scaled, xs => xs.length() <= 20)
   @qc.quick_check(prop, max_size=40)
 }
 ```
@@ -341,8 +341,8 @@ test "combinator sorted array with filter" {
   }
 
   let base = @qc.int_range(-8, 8).array_with_size(3)
-  let prop = @qc.forall(base, fn(arr) {
-    @qc.forall(@qc.one_of_array(arr), fn(x) {
+  let prop = @qc.forall(base, arr => {
+    @qc.forall(@qc.one_of_array(arr), x => {
       arr[0] <= x && x <= arr[arr.length() - 1]
     })
     |> @qc.filter(is_non_decreasing(arr))
@@ -362,8 +362,8 @@ QuickCheck 已经提供 `@qc.sorted_array`，我们可以直接利用它：
 ///|
 test "combinator sorted array constructor" {
   let gen = @qc.sorted_array(5, @qc.int_range(-30, 30))
-  let prop = @qc.forall(gen, fn(arr) {
-    @qc.forall(@qc.one_of_array(arr), fn(x) {
+  let prop = @qc.forall(gen, arr => {
+    @qc.forall(@qc.one_of_array(arr), x => {
       arr[0] <= x && x <= arr[arr.length() - 1]
     })
   })
@@ -477,7 +477,7 @@ fn[T] inorder(tree : Tree[T]) -> Array[T] {
 test "generate BST" {
   let int_arr = @qc.int_range(-100, 100).array_with_size(10)
   let gen_bst = int_arr.fmap(Tree::from_array)
-  let prop = @qc.forall(gen_bst, fn(t) {
+  let prop = @qc.forall(gen_bst, t => {
     let arr = inorder(t)
     arr == arr.copy()..sort()
   })
@@ -506,8 +506,8 @@ fn[T] from_sorted(arr : ArrayView[T]) -> Tree[T] {
 ///|
 test "generate balanced BST" {
   let int_arr = @qc.int_range(-100, 100).array_with_size(10)
-  let gen_bst = int_arr.fmap(fn(arr) { arr..sort()..dedup() |> from_sorted })
-  let prop = @qc.forall(gen_bst, fn(t) {
+  let gen_bst = int_arr.fmap(arr => arr..sort()..dedup() |> from_sorted)
+  let prop = @qc.forall(gen_bst, t => {
     let arr = inorder(t)
     arr == arr.copy()..sort()
   })
@@ -551,7 +551,7 @@ fn gen_bst_ranged(min : Int, max : Int) -> @qc.Gen[Tree[Int]] {
 ///|
 test "generate ranged BST" {
   let gen_bst = gen_bst_ranged(-100, 100)
-  let prop = @qc.forall(gen_bst, fn(t) {
+  let prop = @qc.forall(gen_bst, t => {
     let arr = inorder(t)
     arr == arr.copy()..sort()
   })

--- a/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
@@ -136,13 +136,13 @@ fn[P : Testable, T] @qc.shrinking(
 ```mbt check
 ///|
 fn shrink_even_nat(x : Int) -> Iter[Int] {
-  @qc.Shrink::shrink(x).filter(fn(y) { y >= 0 && y % 2 == 0 })
+  @qc.Shrink::shrink(x).filter(y => y >= 0 && y % 2 == 0)
 }
 
 ///|
 test "forall_shrink keeps even invariant" {
-  let gen = @qc.int_range(0, 100).fmap(fn(x) { x * 2 })
-  let prop = @qc.forall_shrink(gen, shrink_even_nat, fn(x) { x < 20 })
+  let gen = @qc.int_range(0, 100).fmap(x => x * 2)
+  let prop = @qc.forall_shrink(gen, shrink_even_nat, x => x < 20)
   @qc.quick_check(prop, expect=Fail)
 }
 ```
@@ -158,7 +158,7 @@ test "forall_shrink keeps even invariant" {
 ```mbt check
 ///|
 test "shrinking starts from explicit value" {
-  let prop = @qc.shrinking(shrink_even_nat, 84, fn(x) { x < 20 })
+  let prop = @qc.shrinking(shrink_even_nat, 84, x => x < 20)
   @qc.quick_check(prop, expect=Fail)
 }
 ```
@@ -246,9 +246,7 @@ test "shrink sorted array" {
 ///|
 test "forall_shrink for sorted array" {
   let gen = @qc.sorted_array(6, @qc.int_range(0, 9))
-  let prop = @qc.forall_shrink(gen, x => shrink_sorted_array(x, lo=0, hi=10), fn(
-    xs,
-  ) {
+  let prop = @qc.forall_shrink(gen, x => shrink_sorted_array(x, lo=0, hi=10), xs => {
     xs.length() < 3
   })
   let r = @qc.quick_check_silence(prop)
@@ -290,7 +288,7 @@ QuickCheck 为此提供了 `counterexample` 这个组合子。
 ```mbt check
 ///|
 test "counterexample adds derived information" {
-  let prop = @qc.forall(@qc.pure((0, [0, 0, -1])), fn(iarr) {
+  let prop = @qc.forall(@qc.pure((0, [0, 0, -1])), iarr => {
     let (x, arr) = iarr
     let out = remove_first_only(arr.copy(), x)
     @qc.counterexample(!out.contains(x), "after remove: \{out}")
@@ -339,7 +337,7 @@ fn t3_prop_rev_list(xs : @list.List[Int]) -> Bool {
 ///|
 test "classify list distribution" {
   let r = @qc.quick_check_silence(
-    @qc.Arrow(fn(xs : @list.List[Int]) {
+    @qc.Arrow((xs : @list.List[Int]) => {
       t3_prop_rev_list(xs)
       |> @qc.classify(xs.length() > 5, "long list")
       |> @qc.classify(xs.length() <= 5, "short list")
@@ -383,7 +381,7 @@ test "classify list distribution" {
 ```mbt check
 ///|
 test "discard on non-empty lists" {
-  let prop_non_empty = fn(xs : @list.List[Int]) -> @qc.Property {
+  let prop_non_empty = (xs : @list.List[Int]) => {
     (!xs.is_empty()) |> @qc.filter(!xs.is_empty())
   }
   inspect(
@@ -402,7 +400,7 @@ test "discard on non-empty lists" {
 ```mbt check
 ///|
 test "reject all gives up" {
-  let prop_reject = fn(_x : Int) { @qc.filter(true, false) }
+  let prop_reject = (_x : Int) => @qc.filter(true, false)
   inspect(
     @qc.quick_check_silence(@qc.Arrow(prop_reject), expect=GaveUp),
     content="+++ [0/1000/100] Ok, gave up!",
@@ -449,7 +447,7 @@ pub fn[A : @feat.Enumerable + Show, B : Testable] @qc.small_check(
 ```mbt check
 ///|
 test "small check fails on first non-zero int" {
-  let r = @qc.small_check_silence(fn(x : Int) { x == 0 }, max_size=5)
+  let r = @qc.small_check_silence((x : Int) => x == 0, max_size=5)
   inspect(
     r,
     content=(
@@ -518,9 +516,9 @@ impl Show for Nat with output(self, logger) {
 
 ///|
 impl @feat.Enumerable for Nat with enumerate() {
-  @feat.pay(fn() {
+  @feat.pay(() => {
     @feat.singleton(Zero) +
-    @feat.Enumerable::enumerate().fmap(fn(n) { Nat::Succ(n) })
+    @feat.Enumerable::enumerate().fmap(n => Nat::Succ(n))
   })
 }
 
@@ -588,7 +586,7 @@ MoonBit 当前的实现也正是这样组织的。
 ```mbt check
 ///|
 test "small check on nat prefix" {
-  let r = @qc.small_check_silence(fn(n : Nat) { n == Zero }, max_size=5)
+  let r = @qc.small_check_silence((n : Nat) => n == Zero, max_size=5)
   inspect(
     r,
     content=(

--- a/src/internal/utils/common.mbt
+++ b/src/internal/utils/common.mbt
@@ -14,7 +14,7 @@ let global_counter : Ref[Int] = @ref.new(0)
 /// is *not* a stable handle — don't pattern-match on it.
 pub fn fresh_name() -> String {
   let counter = global_counter.val
-  global_counter.update(fn(x) { x + 1 })
+  global_counter.update(x => x + 1)
   "test-" + counter.to_string()
 }
 
@@ -48,9 +48,7 @@ pub fn[T] removes_list(
       @list.empty()
     } else {
       let xs_take = xs.take(k)
-      removes_list(k, n - k, xs_drop)
-      .map(fn(x) { xs_take.concat(x) })
-      .add(xs_drop)
+      removes_list(k, n - k, xs_drop).map(x => xs_take.concat(x)).add(xs_drop)
     }
   }
 }
@@ -69,7 +67,7 @@ pub fn[T] removes_array(k : Int, n : Int, xs : Array[T]) -> Array[Array[T]] {
     if xs1.is_empty() {
       []
     } else {
-      [xs1, ..removes_array(k, n - k, xs1).map(fn(x) { xs2 + x })]
+      [xs1, ..removes_array(k, n - k, xs1).map(x => xs2 + x)]
     }
   }
 }
@@ -128,7 +126,7 @@ pub fn[T] id(x : T) -> T = "%identity"
 /// argument it receives and returns `t`. Typical use is currying away
 /// an unused parameter, e.g. `scale(const_(10))` fixes the size at 10.
 pub fn[T, U] const_(t : T) -> (U) -> T {
-  fn(_) { t }
+  _ => t
 }
 
 ///|
@@ -144,5 +142,5 @@ pub fn[A, B, C] pair_function(f : (A, B) -> C) -> ((A, B)) -> C {
 /// `flip(f)(y, x) == f(x, y)`. Used where a combinator takes a binary
 /// callback in the "wrong" order for a particular idiom.
 pub fn[M, N, Z] flip(f : (M, N) -> Z) -> (N, M) -> Z {
-  fn(x, y) { f(y, x) }
+  (x, y) => f(y, x)
 }

--- a/src/laws/README.mbt.md
+++ b/src/laws/README.mbt.md
@@ -30,7 +30,7 @@ test "associative helper works on integer addition" {
 
 ///|
 test "idempotent helper works on a clamp" {
-  let clamp = fn(x : Int) { if x < 0 { 0 } else { x } }
+  let clamp = (x : Int) => if x < 0 { 0 } else { x }
   assert_eq(idempotent(clamp)(-5), true)
   assert_eq(idempotent(clamp)(7), true)
 }
@@ -41,12 +41,12 @@ test "idempotent helper works on a clamp" {
 ```mbt check
 ///|
 fn succ_pred_axiom() -> Axiom[Int] {
-  Axiom::new(fn(x) { Equivalence::new(x + 1 - 1, x) })
+  Axiom::new(x => Equivalence::new(x + 1 - 1, x))
 }
 
 ///|
 test "axiom converts to a property-shaped function" {
-  let prop = succ_pred_axiom().to_property_eq(fn(x) { x })
+  let prop = succ_pred_axiom().to_property_eq(x => x)
   assert_eq(prop(42), true)
 }
 ```

--- a/src/laws/axiom.mbt
+++ b/src/laws/axiom.mbt
@@ -114,7 +114,7 @@ pub fn[T, U] Axiom::to_property(
   cong : (T) -> U,
   eq : (U, U) -> Bool,
 ) -> (T) -> Bool {
-  fn(x : T) { self.run(x).fmap(cong).equal_by(eq) }
+  (x : T) => self.run(x).fmap(cong).equal_by(eq)
 }
 
 ///|
@@ -135,7 +135,7 @@ pub fn[T, M, N] Axiom::to_property_parametric(
   cong : (T, M) -> N,
   eq : (N, N) -> Bool,
 ) -> ((T, M)) -> Bool {
-  fn(x : (T, M)) { self.run(x.0).fmap(fn(y) { cong(y, x.1) }).equal_by(eq) }
+  (x : (T, M)) => self.run(x.0).fmap(y => cong(y, x.1)).equal_by(eq)
 }
 
 ///|

--- a/src/laws/invariant.mbt
+++ b/src/laws/invariant.mbt
@@ -1,25 +1,25 @@
 ///|
 /// Extensional equality for functions.
 pub fn[A, B : Eq] ext_equal(f : (A) -> B, g : (A) -> B) -> (A) -> Bool {
-  fn(x) { f(x) == g(x) }
+  x => f(x) == g(x)
 }
 
 ///|
 /// Idempotent function.
 pub fn[A : Eq] idempotent(f : (A) -> A) -> (A) -> Bool {
-  fn(x) { f(f(x)) == f(x) }
+  x => f(f(x)) == f(x)
 }
 
 ///|
 /// Involutory function.
 pub fn[A : Eq] involutory(f : (A) -> A) -> (A) -> Bool {
-  fn(x) { f(f(x)) == x }
+  x => f(f(x)) == x
 }
 
 ///|
 /// Inverse function.
 pub fn[A : Eq, B] inverse(f : (A) -> B, g : (B) -> A) -> (A) -> Bool {
-  fn(x) { g(f(x)) == x }
+  x => g(f(x)) == x
 }
 
 ///|
@@ -27,7 +27,7 @@ pub fn[A : Eq, B] inverse(f : (A) -> B, g : (B) -> A) -> (A) -> Bool {
 pub fn[A : Compare, B : Compare] mono_increase(
   f : (A) -> B,
 ) -> ((A, A)) -> Bool {
-  fn(t : (A, A)) {
+  (t : (A, A)) => {
     let (x, y) = t
     x <= y && f(x) <= f(y)
   }
@@ -38,7 +38,7 @@ pub fn[A : Compare, B : Compare] mono_increase(
 pub fn[A : Compare, B : Compare] mono_decrease(
   f : (A) -> B,
 ) -> ((A, A)) -> Bool {
-  fn(t : (A, A)) {
+  (t : (A, A)) => {
     let (x, y) = t
     x <= y && f(x) >= f(y)
   }
@@ -47,7 +47,7 @@ pub fn[A : Compare, B : Compare] mono_decrease(
 ///|
 /// Commutative binary operation.
 pub fn[A, B : Eq] commutative(f : (A, A) -> B) -> ((A, A)) -> Bool {
-  fn(t : (A, A)) {
+  (t : (A, A)) => {
     let (x, y) = t
     f(x, y) == f(y, x)
   }
@@ -56,7 +56,7 @@ pub fn[A, B : Eq] commutative(f : (A, A) -> B) -> ((A, A)) -> Bool {
 ///|
 /// Associative binary operation.
 pub fn[A : Eq] associative(f : (A, A) -> A) -> ((A, A, A)) -> Bool {
-  fn(t : (A, A, A)) {
+  (t : (A, A, A)) => {
     let (x, y, z) = t
     f(f(x, y), z) == f(x, f(y, z))
   }
@@ -68,7 +68,7 @@ pub fn[A : Eq] distributive_left(
   f : (A, A) -> A,
   g : (A, A) -> A,
 ) -> ((A, A, A)) -> Bool {
-  fn(t : (A, A, A)) {
+  (t : (A, A, A)) => {
     let (x, y, z) = t
     f(x, g(y, z)) == g(f(x, y), f(x, z))
   }
@@ -80,7 +80,7 @@ pub fn[A : Eq] distributive_right(
   f : (A, A) -> A,
   g : (A, A) -> A,
 ) -> ((A, A, A)) -> Bool {
-  fn(t : (A, A, A)) {
+  (t : (A, A, A)) => {
     let (x, y, z) = t
     f(g(x, y), z) == g(f(x, z), f(y, z))
   }

--- a/src/shrink.mbt
+++ b/src/shrink.mbt
@@ -20,11 +20,11 @@ impl Shrink with shrink(_a) {
 
 ///|
 pub impl Shrink for Int with shrink(x) {
-  @utils.apply_while_list(x, fn(z) { z / 2 }, fn(z) { (x - z).abs() < x.abs() })
-  .map(fn(i) { x - i })
+  @utils.apply_while_list(x, z => z / 2, z => (x - z).abs() < x.abs())
+  .map(i => x - i)
   .iter()
   .concat(Iter::singleton(0))
-  .filter(fn(u) { u != x })
+  .filter(u => u != x)
 }
 
 ///|
@@ -35,11 +35,11 @@ test "shrink int" {
 
 ///|
 pub impl Shrink for Int64 with shrink(x) {
-  @utils.apply_while_list(x, fn(z) { z / 2 }, fn(z) { (x - z).abs() < x.abs() })
-  .map(fn(i) { x - i })
+  @utils.apply_while_list(x, z => z / 2, z => (x - z).abs() < x.abs())
+  .map(i => x - i)
   .iter()
   .concat(Iter::singleton(0))
-  .filter(fn(u) { u != x })
+  .filter(u => u != x)
 }
 
 ///|
@@ -52,11 +52,11 @@ test "shrink int64" {
 
 ///|
 pub impl Shrink for UInt with shrink(x) {
-  @utils.apply_while_list(x, fn(z) { z / 2 }, fn(z) { z > 0 })
-  .map(fn(i) { x - i })
+  @utils.apply_while_list(x, z => z / 2, z => z > 0)
+  .map(i => x - i)
   .iter()
   .concat(Iter::singleton(0))
-  .filter(fn(u) { u != x })
+  .filter(u => u != x)
 }
 
 ///|
@@ -69,11 +69,11 @@ test "shrink uint" {
 
 ///|
 pub impl Shrink for UInt64 with shrink(x) {
-  @utils.apply_while_list(x, fn(z) { z / 2 }, fn(z) { z > 0 })
-  .map(fn(i) { x - i })
+  @utils.apply_while_list(x, z => z / 2, z => z > 0)
+  .map(i => x - i)
   .iter()
   .concat(Iter::singleton(0))
-  .filter(fn(u) { u != x })
+  .filter(u => u != x)
 }
 
 ///|
@@ -134,7 +134,7 @@ pub impl[T : Shrink] Shrink for T? with shrink(x) {
   match x {
     None => Iter::empty()
     Some(v) =>
-      Shrink::shrink(v).map(fn(v1) { Some(v1) }).concat(Iter::singleton(None))
+      Shrink::shrink(v).map(v1 => Some(v1)).concat(Iter::singleton(None))
   }
 }
 
@@ -164,8 +164,8 @@ test "shrink option" {
 ///|
 pub impl[T : Shrink, E : Shrink] Shrink for Result[T, E] with shrink(x) {
   match x {
-    Ok(v) => Shrink::shrink(v).map(fn(v1) { Ok(v1) })
-    Err(e) => Shrink::shrink(e).map(fn(e1) { Err(e1) })
+    Ok(v) => Shrink::shrink(v).map(v1 => Ok(v1))
+    Err(e) => Shrink::shrink(e).map(e1 => Err(e1))
   }
 }
 
@@ -189,8 +189,8 @@ test "shrink result" {
 pub impl[A : Shrink, B : Shrink] Shrink for (A, B) with shrink(x) {
   let (a, b) = x
   Shrink::shrink(a)
-  .map(fn(a1) { (a1, b) })
-  .concat(Shrink::shrink(b).map(fn(b1) { (a, b1) }))
+  .map(a1 => (a1, b))
+  .concat(Shrink::shrink(b).map(b1 => (a, b1)))
 }
 
 ///|
@@ -211,7 +211,7 @@ test "shrink tuple" {
 ///|
 pub impl[A : Shrink, B : Shrink, C : Shrink] Shrink for (A, B, C) with shrink(x) {
   let (a, b, c) = x
-  Shrink::shrink((a, (b, c))).map(fn(y) {
+  Shrink::shrink((a, (b, c))).map(y => {
     let (a1, (b1, c1)) = y
     (a1, b1, c1)
   })
@@ -222,7 +222,7 @@ pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink] Shrink for (A, B, C, D)
   x,
 ) {
   let (a, b, c, d) = x
-  Shrink::shrink((a, (b, c, d))).map(fn(y) {
+  Shrink::shrink((a, (b, c, d))).map(y => {
     let (a1, (b1, c1, d1)) = y
     (a1, b1, c1, d1)
   })
@@ -237,7 +237,7 @@ pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink] Shrink for 
   E,
 ) with shrink(x) {
   let (a, b, c, d, e) = x
-  Shrink::shrink((a, (b, c, d, e))).map(fn(y) {
+  Shrink::shrink((a, (b, c, d, e))).map(y => {
     let (a1, (b1, c1, d1, e1)) = y
     (a1, b1, c1, d1, e1)
   })
@@ -253,7 +253,7 @@ pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink]
   F,
 ) with shrink(x) {
   let (a, b, c, d, e, f) = x
-  Shrink::shrink((a, (b, c, d, e, f))).map(fn(y) {
+  Shrink::shrink((a, (b, c, d, e, f))).map(y => {
     let (a1, (b1, c1, d1, e1, f1)) = y
     (a1, b1, c1, d1, e1, f1)
   })
@@ -349,8 +349,8 @@ pub fn[T : Shrink + Compare] shrink_sorted_distinct_array(
     Array::makei(l + 1, i => i)
     .iter()
     .flat_map(i => {
-      let lower_ok = fn(x) { if i == 0 { lo <= x } else { nv[i - 1] < x } }
-      let upper_ok = fn(x) { if i == l { x <= hi } else { x < nv[i + 1] } }
+      let lower_ok = x => if i == 0 { lo <= x } else { nv[i - 1] < x }
+      let upper_ok = x => if i == l { x <= hi } else { x < nv[i + 1] }
       T::shrink(nv[i]).flat_map(x => {
         if lower_ok(x) && upper_ok(x) && x != nv[i] {
           let nv1 = nv.copy()
@@ -405,13 +405,13 @@ pub impl[T : Shrink] Shrink for List[T] with shrink(xs) {
       Empty => Iter::empty()
       More(x, tail=xs) =>
         T::shrink(x)
-        .map(fn(x_) { xs.add(x_) })
-        .concat(shr_sub_terms(xs).map(fn(xs_) { xs_.add(x) }))
+        .map(x_ => xs.add(x_))
+        .concat(shr_sub_terms(xs).map(xs_ => xs_.add(x)))
     }
   }
 
-  @utils.apply_while_list(n, fn(x) { x / 2 }, fn(x) { x > 0 })
-  .map(fn(k) { @utils.removes_list(k, n, xs) })
+  @utils.apply_while_list(n, x => x / 2, x => x > 0)
+  .map(k => @utils.removes_list(k, n, xs))
   .flatten()
   .iter()
   .concat(shr_sub_terms(xs))
@@ -420,7 +420,7 @@ pub impl[T : Shrink] Shrink for List[T] with shrink(xs) {
 ///|
 /// Shrink non-empty list without producing the empty list.
 pub fn[T : Shrink] shrink_non_empty_list(xs : List[T]) -> Iter[List[T]] {
-  Shrink::shrink(xs).filter(fn(ys) { !ys.is_empty() })
+  Shrink::shrink(xs).filter(ys => !ys.is_empty())
 }
 
 ///|
@@ -466,13 +466,13 @@ pub impl[X : Shrink] Shrink for Array[X] with shrink(xs) {
       [] => Iter::empty()
       [x, .. xs] =>
         X::shrink(x)
-        .map(fn(x_) { [x_, ..xs] })
-        .concat(shr_sub_terms(xs).map(fn(xs_) { [x, ..xs_] }))
+        .map(x_ => [x_, ..xs])
+        .concat(shr_sub_terms(xs).map(xs_ => [x, ..xs_]))
     }
   }
 
-  @utils.apply_while_array(n, fn(x) { x / 2 }, fn(x) { x > 0 })
-  .map(fn(k) { @utils.removes_array(k, n, xs) })
+  @utils.apply_while_array(n, x => x / 2, x => x > 0)
+  .map(k => @utils.removes_array(k, n, xs))
   .flatten()
   .iter()
   .concat(shr_sub_terms(view))
@@ -520,16 +520,16 @@ test "shrink non-empty array" {
 ///|
 pub impl[X : Shrink] Shrink for Iter[X] with shrink(xs) {
   let arr = xs.to_array()
-  let its : Array[_] = Array::makei(arr.length(), fn(x) {
+  let its : Array[_] = Array::makei(arr.length(), x => {
     X::shrink(arr[x])
-    .map(fn(y) {
+    .map(y => {
       let cp = arr.copy()
       cp[x] = y
       cp.iter()
     })
     .to_array()
   }).flatten()
-  let rms : Array[Iter[X]] = arr.mapi(fn(i, _) {
+  let rms : Array[Iter[X]] = arr.mapi((i, _) => {
     let a = arr.copy()
     a.remove(i) |> ignore
     a.iter()

--- a/src/state.mbt
+++ b/src/state.mbt
@@ -109,7 +109,7 @@ fn from_config(cfg : Config) -> State {
     max_success_tests_: cfg.max_success,
     max_discarded_ratio_: cfg.max_discard_ratio,
     max_shrinks_: cfg.max_shrink,
-    replay_start_size_: cfg.replay.map(fn(x) { x.1 }),
+    replay_start_size_: cfg.replay.map(x => x.1),
     num_success_tests: 0,
     num_discarded_tests: 0,
     num_recent_discarded_tests: 0,
@@ -204,7 +204,7 @@ fn State::discarded_too_much(self : State) -> Bool {
 
 ///|
 fn State::callback_post_test(self : State, res : SingleResult) -> Unit {
-  res.callbacks.each(fn(cb) {
+  res.callbacks.each(cb => {
     match cb {
       PostTest(_, f) => f(self, res)
       _ => ()
@@ -214,7 +214,7 @@ fn State::callback_post_test(self : State, res : SingleResult) -> Unit {
 
 ///|
 fn State::callback_post_final_failure(self : State, res : SingleResult) -> Unit {
-  res.callbacks.each(fn(cb) {
+  res.callbacks.each(cb => {
     match cb {
       PostFinalFailure(_, f) => f(self, res)
       _ => ()
@@ -289,7 +289,7 @@ fn Coverage::class_incr(
 ///|
 fn Coverage::label_to_string(self : Coverage, success : Int) -> String {
   let res = []
-  self.labels.each(fn(list, i) {
+  self.labels.each((list, i) => {
     if list.0.is_empty() {
       return
     } else {
@@ -303,7 +303,7 @@ fn Coverage::label_to_string(self : Coverage, success : Int) -> String {
 ///|
 fn Coverage::class_to_string(self : Coverage, success : Int) -> String {
   let res = []
-  self.classes.each(fn(s, i) {
+  self.classes.each((s, i) => {
     res.push("\{i.to_double() / success.to_double() * 100}% : \{s}")
   })
   res.join("\n")

--- a/src/testable.mbt
+++ b/src/testable.mbt
@@ -27,7 +27,7 @@ priv enum Kind {
 
 ///|
 fn[T] promote_rose(s : Rose[Gen[T]]) -> Gen[Rose[T]] {
-  delay().fmap(fn(m) { s.fmap(m) })
+  delay().fmap(m => s.fmap(m))
 }
 
 ///|
@@ -120,7 +120,7 @@ pub impl[P : Testable, A : @coreqc.Arbitrary + Shrink + Show] Testable for Arrow
   A,
   P,
 ] with property(self) {
-  forall_shrink(Gen::spawn(), A::shrink, fn(a : A) { try? (self.0)(a) })
+  forall_shrink(Gen::spawn(), A::shrink, (a : A) => try? (self.0)(a))
 }
 
 ///|
@@ -139,7 +139,7 @@ pub fn[P : Testable] map_total_result(
   prop : P,
   f : (SingleResult) -> SingleResult,
 ) -> Property {
-  run_prop(prop).fmap(fn(rose) { rose.fmap(f) })
+  run_prop(prop).fmap(rose => rose.fmap(f))
 }
 
 ///|
@@ -164,7 +164,7 @@ pub fn[P : Testable, T] shrinking(
     Rose(pf(x) |> run_prop, shrinker(x).map(props))
   }
 
-  promote_rose(props(x0)).fmap(fn(x) { x.join() })
+  promote_rose(props(x0)).fmap(x => x.join())
 }
 
 ///|
@@ -172,13 +172,13 @@ pub fn[P : Testable, T] shrinking(
 /// callback receives the driver state and result; typical use is to
 /// print diagnostics on a shrunk counter-example.
 pub fn[P : Testable] callback(p : P, cb : Callback) -> Property {
-  map_total_result(p, fn(res) { { ..res, callbacks: res.callbacks.add(cb) } })
+  map_total_result(p, res => { ..res, callbacks: res.callbacks.add(cb) })
 }
 
 ///|
 /// Attaches a label to a test case
 pub fn[P : Testable] label(p : P, s : String) -> Property {
-  map_total_result(p, fn(res) { { ..res, labels: res.labels.add(s) } })
+  map_total_result(p, res => { ..res, labels: res.labels.add(s) })
 }
 
 ///|
@@ -190,14 +190,14 @@ pub fn[P : Testable, T : Show] collect(p : P, t : T) -> Property {
 ///|
 /// Classifies a test case based on a condition
 pub fn[P : Testable] classify(p : P, cond : Bool, s : String) -> Property {
-  map_total_result(p, fn(res) { { ..res, classes: res.classes.add((s, cond)) } })
+  map_total_result(p, res => { ..res, classes: res.classes.add((s, cond)) })
 }
 
 ///|
 /// Adds a string to the counterexample if the property fails
 pub fn[P : Testable] counterexample(p : P, s : String) -> Property {
-  let cb = callback(p, PostFinalFailure(CounterExample, fn(_st, _res) {  }))
-  map_total_result(cb, fn(res) { { ..res, test_case: res.test_case.add(s) } })
+  let cb = callback(p, PostFinalFailure(CounterExample, (_st, _res) => ()))
+  map_total_result(cb, res => { ..res, test_case: res.test_case.add(s) })
 }
 
 ///|
@@ -212,12 +212,12 @@ pub fn[P : Testable] filter(p : P, cond : Bool) -> Property {
 ///|
 /// Run with an explicit generator
 pub fn[T : Testable, A : Show] forall(gen : Gen[A], f : (A) -> T) -> Property {
-  forall_shrink(gen, fn(_x) { Iter::empty() }, f)
+  forall_shrink(gen, _x => Iter::empty(), f)
 }
 
 ///|
 /// Run a property with an explicit generator and shrinker. `forall`
-/// is a convenience that passes `fn(_) { Iter::empty() }` — use this
+/// is a convenience that passes `_ => Iter::empty()` — use this
 /// version when you want a hand-rolled shrinker without going through
 /// the `Shrink` trait.
 pub fn[T : Testable, A : Show] forall_shrink(
@@ -225,8 +225,8 @@ pub fn[T : Testable, A : Show] forall_shrink(
   shrinker : (A) -> Iter[A],
   f : (A) -> T,
 ) -> Property {
-  gen.bind(fn(x) {
-    shrinking(shrinker, x, fn(a : A) {
+  gen.bind(x => {
+    shrinking(shrinker, x, (a : A) => {
       let s = a.to_string()
       counterexample(f(a), s)
     }).0
@@ -238,7 +238,7 @@ pub fn[T : Testable, A : Show] forall_shrink(
 pub fn[P : Testable] if_fail(p : P, f : () -> Unit) -> Property {
   callback(
     p,
-    PostTest(Nothing, fn(_st, res) {
+    PostTest(Nothing, (_st, res) => {
       match res.ok {
         Some(false) => f()
         _ => ()

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -109,7 +109,7 @@ pub(all) struct Replay {
 /// For the user this shows up as `@qc.Arrow(prop)` at the driver
 /// boundary:
 ///
-///     @qc.quick_check(@qc.Arrow(fn(x : Int) -> Bool { x == x }))
+///     @qc.quick_check(@qc.Arrow((x : Int) => x == x))
 ///
 /// Most users never see `Arrow` directly because `quick_check_fn`
 /// wraps the function for them. Reach for the explicit form only when


### PR DESCRIPTION
## Summary
- Codebase-wide sweep converting every anonymous `fn(args) { body }` passed as a callback (or bound by `let`) to MoonBit arrow syntax — `() => body`, `x => body`, `(x, y) => body`.
- Top-level `pub fn` / `priv fn` / `fn name(...)` declarations untouched.
- Includes a `moon fmt` reflow of the touched files.

Follow-on to the `feat-api-cleanup` PR (#99) which started the same conversion in the touched files; this PR finishes the job across the rest of the repo.

## Test plan
- [x] `moon check --no-render` — clean
- [x] `moon test` — 252/252 pass
- [x] `moon fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
