### PR TITLE
docs: add inline docstring tests for public APIs

### DIFF
--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -26,6 +26,13 @@ pub fn[T] Enumerate::eval(self : Enumerate[T]) -> LazyList[Finite[T]] {
 
 ///|
 /// The empty enumeration: no values at any size. Identity for `union`.
+///
+/// ```mbt check
+/// test {
+///   let e : Enumerate[Int] = empty()
+///   inspect(e.eval(), content="[]")
+/// }
+/// ```
 pub fn[T] empty() -> Enumerate[T] {
   { parts: Nil }
 }
@@ -33,6 +40,13 @@ pub fn[T] empty() -> Enumerate[T] {
 ///|
 /// One-value enumeration at size 0. Building block for `Enumerable`
 /// instances of leaf constructors.
+///
+/// ```mbt check
+/// test {
+///   let e : Enumerate[String] = singleton("leaf")
+///   assert_eq(e.at(0), "leaf")
+/// }
+/// ```
 pub fn[T] singleton(val : T) -> Enumerate[T] {
   { parts: Cons(fin_pure(val), @lazy.LazyRef::from_value(Nil)) }
 }
@@ -43,6 +57,14 @@ pub fn[T] singleton(val : T) -> Enumerate[T] {
 /// inside the current part, then read the value via `fIndex`.
 ///
 /// **Aborts** on out-of-range indices (reaches `Nil`).
+///
+/// ```mbt check
+/// test {
+///   let bools : Enumerate[Bool] = Enumerable::enumerate()
+///   assert_eq(bools[0], true)
+///   assert_eq(bools[1], false)
+/// }
+/// ```
 #alias("_[_]")
 #alias(en_index, deprecated="Use `_[_]` instead")
 pub fn[T] Enumerate::at(self : Enumerate[T], idx : BigInt) -> T {
@@ -100,6 +122,15 @@ pub impl[T] Add for Enumerate[T] with add(self, other) {
 ///|
 /// Rewrite every element without changing the structure: part shapes
 /// stay the same, only the inhabitants are relabelled via `f`.
+///
+/// ```mbt check
+/// test {
+///   let bools : Enumerate[Bool] = Enumerable::enumerate()
+///   let labels = bools.fmap(b => if b { "yes" } else { "no" })
+///   assert_eq(labels[0], "yes")
+///   assert_eq(labels[1], "no")
+/// }
+/// ```
 pub fn[T, U] Enumerate::fmap(self : Enumerate[T], f : (T) -> U) -> Enumerate[U] {
   { parts: self.parts.map(x => fin_fmap(f, x)) }
 }

--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -140,6 +140,13 @@ fn[M] fin_mconcat(val : LazyList[Finite[M]]) -> Finite[M] {
 ///
 /// The traversal is lazy: early `break` stops calling `fIndex`.
 /// Like every `Iter` in MoonBit it is single-shot.
+///
+/// ```mbt check
+/// test {
+///   let squares : Finite[BigInt] = { fCard: 4, fIndex: j => j * j }
+///   assert_eq(squares.iter().collect(), [0, 1, 4, 9])
+/// }
+/// ```
 pub fn[T] Finite::iter(self : Finite[T]) -> Iter[T] {
   let card = self.fCard
   let fi = self.fIndex
@@ -192,6 +199,13 @@ test "iter is lazy — early break stops walking" {
 ///|
 /// Materialise a `Finite` to `(cardinality, list of all elements)`.
 /// Eagerly evaluates every element — only suitable for small chunks.
+///
+/// ```mbt check
+/// test {
+///   let f : Finite[BigInt] = { fCard: 3, fIndex: j => j }
+///   inspect(f.to_array(), content="(3, @list.from_array([0, 1, 2]))")
+/// }
+/// ```
 pub fn[T] Finite::to_array(self : Finite[T]) -> (BigInt, @list.List[T]) {
   (
     self.fCard,

--- a/src/gen.mbt
+++ b/src/gen.mbt
@@ -62,12 +62,27 @@ pub fn[T] Gen::samples(
 
 ///|
 /// Functor instance for Gen[T] (pure)
+///
+/// ```mbt check
+/// test {
+///   // A pure generator ignores size and rng and always yields the value.
+///   assert_eq(pure(42).sample(), 42)
+///   assert_eq(pure("hi").sample(), "hi")
+/// }
+/// ```
 pub fn[T] pure(val : T) -> Gen[T] {
   Gen((_, _) => val)
 }
 
 ///|
 /// Functor instance for Gen[T] (fmap)
+///
+/// ```mbt check
+/// test {
+///   let doubled = pure(21).fmap(x => x * 2)
+///   assert_eq(doubled.sample(), 42)
+/// }
+/// ```
 pub fn[T, U] Gen::fmap(self : Gen[T], f : (T) -> U) -> Gen[U] {
   Gen((n, s) => f(self.run(n, s)))
 }
@@ -80,6 +95,15 @@ pub fn[T, U] Gen::ap(self : Gen[(T) -> U], v : Gen[T]) -> Gen[U] {
 
 ///|
 /// Monad instance for Gen[T]
+///
+/// ```mbt check
+/// test {
+///   // Use bind to sequence generators: first pick `n`, then draw an
+///   // `n`-element list of the fixed value 0.
+///   let g = pure(3).bind(n => pure(0).list_with_size(n))
+///   inspect(g.sample(), content="@list.from_array([0, 0, 0])")
+/// }
+/// ```
 pub fn[T, U] Gen::bind(self : Gen[T], f : (T) -> Gen[U]) -> Gen[U] {
   Gen((n, s) => {
     let s2 = s.split()
@@ -169,6 +193,13 @@ fn[T] delay() -> Gen[(Gen[T]) -> T] {
 
 ///|
 /// Create tuple generator from two generators
+///
+/// ```mbt check
+/// test {
+///   let g : Gen[(Int, String)] = tuple(pure(7), pure("x"))
+///   assert_eq(g.sample(), (7, "x"))
+/// }
+/// ```
 pub fn[T, U] tuple(gen1 : Gen[T], gen2 : Gen[U]) -> Gen[(T, U)] {
   gen1.bind(x => gen2.fmap(y => (x, y)))
 }
@@ -369,6 +400,18 @@ pub fn[T] backtrack(gs : Array[(UInt, Gen[T?])]) -> Gen[T?] {
 ///|
 /// Chooses one of the given generators, with a weighted random distribution.
 /// @alert unsafe "Panics if the array is empty or total weight is zero"
+///
+/// ```mbt check
+/// test {
+///   // 90% chance of "common", 10% chance of "rare". With a fixed seed
+///   // the draws are deterministic — over 10 samples we expect mostly
+///   // "common".
+///   let g = frequency([(9U, pure("common")), (1U, pure("rare"))])
+///   for x in g.samples() {
+///     assert_true(x == "common" || x == "rare")
+///   }
+/// }
+/// ```
 pub fn[T] frequency(arr : Array[(UInt, Gen[T])]) -> Gen[T] {
   if arr.is_empty() {
     abort("frequency: empty array")
@@ -438,8 +481,17 @@ pub fn[T, E] flatten_result(res : Result[Gen[T], E]) -> Gen[Result[T, E]] {
 }
 
 ///|
-/// Randomly uses one of the given generators. 
+/// Randomly uses one of the given generators.
 /// @alert unsafe "Panics if the array is empty"
+///
+/// ```mbt check
+/// test {
+///   let g = one_of([pure(1), pure(2), pure(3)])
+///   for x in g.samples() {
+///     assert_true(x == 1 || x == 2 || x == 3)
+///   }
+/// }
+/// ```
 pub fn[T] one_of(arr : Array[Gen[T]]) -> Gen[T] {
   int_bound(arr.length()).bind(x => arr[x])
 }
@@ -510,6 +562,14 @@ pub fn alphabet() -> Gen[Char] {
 
 ///|
 /// Generates int within given bound [0, bound)
+///
+/// ```mbt check
+/// test {
+///   for x in int_bound(100).samples() {
+///     assert_true(x >= 0 && x < 100)
+///   }
+/// }
+/// ```
 pub fn int_bound(bound : Int) -> Gen[Int] {
   if bound == 0 {
     pure(0)
@@ -530,6 +590,15 @@ pub fn integer_bound(bound : BigInt) -> Gen[BigInt] {
 
 ///|
 /// Generates int within given range [lo, hi)
+///
+/// ```mbt check
+/// test {
+///   let g = int_range(10, 20)
+///   for x in g.samples() {
+///     assert_true(x >= 10 && x < 20)
+///   }
+/// }
+/// ```
 pub fn int_range(lo : Int, hi : Int) -> Gen[Int] {
   guard lo != hi else { pure(lo) }
   Gen((_, rs) => {
@@ -547,6 +616,13 @@ pub fn char_range(lo : Char, hi : Char) -> Gen[Char] {
 ///|
 /// Lift a per-element generator to a generator of lists with exactly
 /// `size` elements (fixed length, independent draws).
+///
+/// ```mbt check
+/// test {
+///   let g = pure(42).list_with_size(3)
+///   inspect(g.sample(), content="@list.from_array([42, 42, 42])")
+/// }
+/// ```
 pub fn[T] Gen::list_with_size(gen : Gen[T], size : Int) -> Gen[List[T]] {
   for n = size, acc = pure(@list.empty()) {
     if n <= 0 {
@@ -575,6 +651,13 @@ pub fn[T : Compare] sorted_array(size : Int, gen : Gen[T]) -> Gen[Array[T]] {
 /// Lift a per-element generator to a generator of arrays with exactly
 /// `size` elements. Each element is drawn independently from the same
 /// sample tree.
+///
+/// ```mbt check
+/// test {
+///   let g = pure(0).array_with_size(4)
+///   assert_eq(g.sample(), [0, 0, 0, 0])
+/// }
+/// ```
 pub fn[T] Gen::array_with_size(self : Gen[T], size : Int) -> Gen[Array[T]] {
   Gen((i, rs) => Array::makei(size, _ => self.run(i, rs)))
 }

--- a/src/internal/lazy/lazy.mbt
+++ b/src/internal/lazy/lazy.mbt
@@ -16,6 +16,13 @@ struct LazyRef[T] {
 ///|
 /// Promote an already-evaluated value to a `LazyRef`. `force` on the
 /// result returns immediately without computing anything.
+///
+/// ```mbt check
+/// test {
+///   let r = LazyRef::from_value(7)
+///   assert_eq(r.force(), 7)
+/// }
+/// ```
 pub fn[T] LazyRef::from_value(val : T) -> LazyRef[T] {
   { body: Value(val) }
 }
@@ -23,6 +30,20 @@ pub fn[T] LazyRef::from_value(val : T) -> LazyRef[T] {
 ///|
 /// Wrap a delayed computation as a `LazyRef`. The thunk runs the first
 /// time `force` is called; subsequent forces return the cached value.
+///
+/// ```mbt check
+/// test {
+///   let runs = Ref::new(0)
+///   let r = LazyRef::from_thunk(() => {
+///     runs.val = runs.val + 1
+///     "hi"
+///   })
+///   assert_eq(runs.val, 0)
+///   assert_eq(r.force(), "hi")
+///   assert_eq(r.force(), "hi")
+///   assert_eq(runs.val, 1)
+/// }
+/// ```
 pub fn[T] LazyRef::from_thunk(f : () -> T) -> LazyRef[T] {
   { body: Thunk(f) }
 }
@@ -30,6 +51,13 @@ pub fn[T] LazyRef::from_thunk(f : () -> T) -> LazyRef[T] {
 ///|
 /// Read the value, running the thunk on first access and caching the
 /// result in place. Idempotent and O(1) after the first call.
+///
+/// ```mbt check
+/// test {
+///   let r = LazyRef::from_thunk(() => 1 + 2)
+///   assert_eq(r.force(), 3)
+/// }
+/// ```
 pub fn[T] LazyRef::force(self : LazyRef[T]) -> T {
   match self.body {
     Value(v) => v

--- a/src/internal/lazy/lazy_list.mbt
+++ b/src/internal/lazy/lazy_list.mbt
@@ -68,6 +68,14 @@ pub fn[T] LazyList::iter(self : LazyList[T]) -> Iter[T] {
 ///|
 /// Return the element at position `i`. **O(n)** — walks the list from
 /// the head. Aborts if `i` is negative or past the end.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([10, 20, 30]))
+///   assert_eq(xs.index(0), 10)
+///   assert_eq(xs.index(2), 30)
+/// }
+/// ```
 pub fn[T] LazyList::index(self : LazyList[T], i : Int) -> T {
   if i < 0 {
     abort("index out of bounds")
@@ -86,6 +94,13 @@ pub fn[T] LazyList::index(self : LazyList[T], i : Int) -> T {
 /// Promote an eager `@list.List[T]` to its lazy counterpart. The
 /// resulting `LazyList` has its tails in `LazyRef::from_value` form,
 /// so no delayed computation is involved — just a type conversion.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = to_lazy(@list.from_array([1, 2, 3]))
+///   assert_eq(xs.iter().collect(), [1, 2, 3])
+/// }
+/// ```
 pub fn[T] to_lazy(ls : @list.List[T]) -> LazyList[T] {
   match ls {
     Empty => Nil
@@ -98,6 +113,14 @@ pub fn[T] to_lazy(ls : @list.List[T]) -> LazyList[T] {
 /// with `Nil`. The outer result is also a `LazyList`, so `tails` is
 /// safe to apply to an infinite input — only the suffixes you inspect
 /// are forced.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2, 3]))
+///   let lens = xs.tails().iter().map(t => t.length()).collect()
+///   assert_eq(lens, [3, 2, 1, 0])
+/// }
+/// ```
 pub fn[T] LazyList::tails(self : LazyList[T]) -> LazyList[LazyList[T]] {
   fn go(xs) {
     Cons(
@@ -116,6 +139,14 @@ pub fn[T] LazyList::tails(self : LazyList[T]) -> LazyList[LazyList[T]] {
 /// Lazy append. `(xs.concat(ys)).take(n)` only forces as many cells
 /// as are consumed; the right-hand list is not touched until the left
 /// runs out.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2]))
+///   let ys : LazyList[Int] = from_list(@list.from_array([3, 4]))
+///   assert_eq(xs.concat(ys).iter().collect(), [1, 2, 3, 4])
+/// }
+/// ```
 pub fn[T] LazyList::concat(
   self : LazyList[T],
   other : LazyList[T],
@@ -134,6 +165,12 @@ pub impl[T] Add for LazyList[T] with add(self, other) {
 
 ///|
 /// An infinite stream of a single value: `[x, x, x, ...]`.
+///
+/// ```mbt check
+/// test {
+///   assert_eq(repeat('a').take(4).iter().collect(), ['a', 'a', 'a', 'a'])
+/// }
+/// ```
 pub fn[T] repeat(val : T) -> LazyList[T] {
   Cons(val, LazyRef::from_thunk(() => repeat(val)))
 }
@@ -141,6 +178,13 @@ pub fn[T] repeat(val : T) -> LazyList[T] {
 ///|
 /// Apply `f` to every element. Lazy — `map(f, xs).take(n)` only
 /// forces the first `n` cells.
+///
+/// ```mbt check
+/// test {
+///   let squared = infinite_stream(1, 1).map(x => x * x).take(4)
+///   assert_eq(squared.iter().collect(), [1, 4, 9, 16])
+/// }
+/// ```
 pub fn[T, U] LazyList::map(self : LazyList[T], f : (T) -> U) -> LazyList[U] {
   match self {
     Nil => Nil
@@ -151,6 +195,15 @@ pub fn[T, U] LazyList::map(self : LazyList[T], f : (T) -> U) -> LazyList[U] {
 ///|
 /// Split at index `i`: returns `(take(i), drop(i))` in a single pass.
 /// The prefix is eagerly collected; the suffix stays lazy.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2, 3, 4]))
+///   let (lhs, rhs) = xs.split_at(2)
+///   assert_eq(lhs.iter().collect(), [1, 2])
+///   assert_eq(rhs.iter().collect(), [3, 4])
+/// }
+/// ```
 pub fn[T] LazyList::split_at(
   self : LazyList[T],
   i : Int,
@@ -183,6 +236,13 @@ pub fn[T] LazyList::split_at(
 ///|
 /// Left fold. **Forces the entire list** before returning — not safe
 /// on infinite input.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2, 3, 4]))
+///   assert_eq(xs.fold_left((acc, x) => acc + x, init=0), 10)
+/// }
+/// ```
 pub fn[T, U] LazyList::fold_left(
   self : LazyList[T],
   f : (U, T) -> U,
@@ -231,6 +291,15 @@ pub fn[T] LazyList::tail(self : LazyList[T]) -> LazyList[T] {
 ///|
 /// Number of elements. **Forces the entire list** — don't call on
 /// infinite input.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2, 3]))
+///   assert_eq(xs.length(), 3)
+///   let ys : LazyList[Int] = Nil
+///   assert_eq(ys.length(), 0)
+/// }
+/// ```
 pub fn[T] LazyList::length(self : LazyList[T]) -> Int {
   self.fold_left((acc, _x) => acc + 1, init=0)
 }
@@ -244,6 +313,15 @@ pub fn[X : Add] sum(l : LazyList[X], init~ : X) -> X {
 ///|
 /// Element-wise combine. Stops when either input ends — the shorter
 /// list wins and the rest of the longer one is ignored.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2, 3]))
+///   let ys : LazyList[Int] = from_list(@list.from_array([10, 20]))
+///   let zs = zip_with((a, b) => a + b, xs, ys)
+///   assert_eq(zs.iter().collect(), [11, 22])
+/// }
+/// ```
 pub fn[A, B, C] zip_with(
   f : (A, B) -> C,
   xs : LazyList[A],
@@ -262,6 +340,14 @@ pub fn[A, B, C] zip_with(
 ///|
 /// Prefix of the list whose elements satisfy `p`. Stops at the first
 /// element that fails; the rest is not forced.
+///
+/// ```mbt check
+/// test {
+///   let nats : LazyList[Int] = infinite_stream(0, 1)
+///   let small = nats.take_while(x => x < 4)
+///   assert_eq(small.iter().collect(), [0, 1, 2, 3])
+/// }
+/// ```
 pub fn[T] LazyList::take_while(
   self : LazyList[T],
   p : (T) -> Bool,
@@ -280,6 +366,13 @@ pub fn[T] LazyList::take_while(
 ///|
 /// First `n` elements (or fewer, if the list is shorter). Lazy in the
 /// tail — subsequent cells aren't forced unless requested.
+///
+/// ```mbt check
+/// test {
+///   let nats : LazyList[Int] = infinite_stream(0, 1)
+///   assert_eq(nats.take(3).iter().collect(), [0, 1, 2])
+/// }
+/// ```
 pub fn[T] LazyList::take(self : LazyList[T], n : Int) -> LazyList[T] {
   if n <= 0 {
     Nil
@@ -294,6 +387,13 @@ pub fn[T] LazyList::take(self : LazyList[T], n : Int) -> LazyList[T] {
 ///|
 /// Everything after the first `n` elements. Walks the first `n` cells
 /// (forcing them) and returns the remaining suspension.
+///
+/// ```mbt check
+/// test {
+///   let nats : LazyList[Int] = infinite_stream(0, 1)
+///   assert_eq(nats.drop(3).take(3).iter().collect(), [3, 4, 5])
+/// }
+/// ```
 pub fn[T] LazyList::drop(self : LazyList[T], n : Int) -> LazyList[T] {
   if n <= 0 {
     self
@@ -331,6 +431,13 @@ pub fn[T] LazyList::drop_while(
 ///|
 /// Infinite arithmetic progression: `[start, start + step, start + 2*step, ...]`.
 /// `X` must be `Add`-able. Lazy — consume via `take` / `take_while`.
+///
+/// ```mbt check
+/// test {
+///   let evens = infinite_stream(0, 2).take(5)
+///   assert_eq(evens.iter().collect(), [0, 2, 4, 6, 8])
+/// }
+/// ```
 pub fn[X : Add] infinite_stream(start : X, step : X) -> LazyList[X] {
   Cons(start, LazyRef::from_thunk(() => infinite_stream(start + step, step)))
 }
@@ -358,6 +465,14 @@ pub fn[A, B, C] zip_lazy_normal(
 /// the size-indexed parts of two `Enumerate`s in `feat` — if one
 /// enumeration runs out of parts, the other's remaining parts pass
 /// through unchanged.
+///
+/// ```mbt check
+/// test {
+///   let xs : LazyList[Int] = from_list(@list.from_array([1, 2]))
+///   let ys : LazyList[Int] = from_list(@list.from_array([10, 20, 30, 40]))
+///   assert_eq(zip_plus((a, b) => a + b, xs, ys).iter().collect(), [11, 22, 30, 40])
+/// }
+/// ```
 pub fn[T] zip_plus(
   f : (T, T) -> T,
   ls1 : LazyList[T],

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -36,6 +36,13 @@ pub fn[T] Rose::new(val : T, branch : Iter[Rose[T]]) -> Rose[T] {
 /// The inner tree at the root contributes its value and its branches;
 /// the outer tree's branches are recursively joined and prepended to
 /// the inner branches. Used internally to implement `bind`.
+///
+/// ```mbt check
+/// test {
+///   let nested : Rose[Rose[Int]] = pure(pure(42))
+///   assert_eq(nested.join().iter().collect(), [42])
+/// }
+/// ```
 pub fn[T] Rose::join(self : Rose[Rose[T]]) -> Rose[T] {
   let tss = self.branch
   let ts = self.val.branch
@@ -45,6 +52,14 @@ pub fn[T] Rose::join(self : Rose[Rose[T]]) -> Rose[T] {
 ///|
 /// The unit of the `Rose` monad: a leaf carrying `val` with no
 /// alternatives.
+///
+/// ```mbt check
+/// test {
+///   let r : Rose[String] = pure("hello")
+///   assert_eq(r.val, "hello")
+///   assert_eq(r.branch.collect().length(), 0)
+/// }
+/// ```
 pub fn[T] pure(val : T) -> Rose[T] {
   { val, branch: Iter::empty() }
 }
@@ -53,6 +68,14 @@ pub fn[T] pure(val : T) -> Rose[T] {
 /// Map `f` over every node in the tree, preserving structure. The
 /// result has the same shape as `self`, with each node's value
 /// replaced by `f(value)`.
+///
+/// ```mbt check
+/// test {
+///   let tree = Rose::{ val: 1, branch: [pure(2), pure(3)].iter() }
+///   let doubled = tree.fmap(x => x * 2)
+///   assert_eq(doubled.iter().collect(), [2, 4, 6])
+/// }
+/// ```
 pub fn[T, U] Rose::fmap(self : Rose[T], f : (T) -> U) -> Rose[U] {
   { val: f(self.val), branch: self.branch.map(x => x.fmap(f)) }
 }
@@ -60,6 +83,13 @@ pub fn[T, U] Rose::fmap(self : Rose[T], f : (T) -> U) -> Rose[U] {
 ///|
 /// Monadic bind: replace each node's value with the tree produced by
 /// `f`. Equivalent to `self.fmap(f).join()`.
+///
+/// ```mbt check
+/// test {
+///   let r = pure(3).bind(x => pure(x * x))
+///   assert_eq(r.iter().collect(), [9])
+/// }
+/// ```
 pub fn[T, U] Rose::bind(self : Rose[T], f : (T) -> Rose[U]) -> Rose[U] {
   self.fmap(f).join()
 }

--- a/src/internal/utils/common.mbt
+++ b/src/internal/utils/common.mbt
@@ -35,6 +35,16 @@ pub fn fresh_name() -> String {
 /// Part of the classical QuickCheck list shrinker: combining the
 /// outputs for different chunk sizes produces a "halve toward empty"
 /// shrinking strategy.
+///
+/// ```mbt check
+/// test {
+///   let xs = @list.from_array([1, 2, 3, 4, 5, 6])
+///   inspect(
+///     removes_list(2, 6, xs),
+///     content="@list.from_array([@list.from_array([3, 4, 5, 6]), @list.from_array([1, 2, 5, 6])])",
+///   )
+/// }
+/// ```
 pub fn[T] removes_list(
   k : Int,
   n : Int,
@@ -58,6 +68,15 @@ pub fn[T] removes_list(
 /// semantics: emit one `xs[:i] ++ xs[i+k:]` per chunk boundary `i`,
 /// skipping the trailing chunk whose removal would leave the prefix
 /// unchanged.
+///
+/// ```mbt check
+/// test {
+///   assert_eq(removes_array(2, 6, [1, 2, 3, 4, 5, 6]), [
+///     [3, 4, 5, 6],
+///     [1, 2, 5, 6],
+///   ])
+/// }
+/// ```
 pub fn[T] removes_array(k : Int, n : Int, xs : Array[T]) -> Array[Array[T]] {
   if k > n {
     []
@@ -83,6 +102,15 @@ pub fn[T] removes_array(k : Int, n : Int, xs : Array[T]) -> Array[Array[T]] {
 ///
 ///     apply_while_list(16, z => z / 2, z => z > 0)
 ///     // yields [1, 2, 4, 8]   -- note: 1 is newest, 8 is oldest
+///
+/// ```mbt check
+/// test {
+///   inspect(
+///     apply_while_list(16, z => z / 2, z => z > 0),
+///     content="@list.from_array([1, 2, 4, 8])",
+///   )
+/// }
+/// ```
 pub fn[T] apply_while_list(
   x : T,
   f : (T) -> T,
@@ -101,6 +129,12 @@ pub fn[T] apply_while_list(
 ///|
 /// Array-shaped counterpart of `apply_while_list`. Same reverse-order
 /// accumulation: newest-kept value first, oldest last.
+///
+/// ```mbt check
+/// test {
+///   assert_eq(apply_while_array(16, z => z / 2, z => z > 0), [1, 2, 4, 8])
+/// }
+/// ```
 pub fn[T] apply_while_array(
   x : T,
   f : (T) -> T,
@@ -119,12 +153,27 @@ pub fn[T] apply_while_array(
 ///|
 /// The identity function: returns its argument unchanged. Bound to the
 /// `%identity` intrinsic, so it compiles to a no-op.
+///
+/// ```mbt check
+/// test {
+///   assert_eq(id(42), 42)
+///   assert_eq(id("moon"), "moon")
+/// }
+/// ```
 pub fn[T] id(x : T) -> T = "%identity"
 
 ///|
 /// `const_(t)` is the constant function at `t`: it ignores whatever
 /// argument it receives and returns `t`. Typical use is currying away
 /// an unused parameter, e.g. `scale(const_(10))` fixes the size at 10.
+///
+/// ```mbt check
+/// test {
+///   let always_seven : (Int) -> Int = const_(7)
+///   assert_eq(always_seven(0), 7)
+///   assert_eq(always_seven(999), 7)
+/// }
+/// ```
 pub fn[T, U] const_(t : T) -> (U) -> T {
   _ => t
 }
@@ -141,6 +190,14 @@ pub fn[A, B, C] pair_function(f : (A, B) -> C) -> ((A, B)) -> C {
 /// Swap the argument order of a binary function:
 /// `flip(f)(y, x) == f(x, y)`. Used where a combinator takes a binary
 /// callback in the "wrong" order for a particular idiom.
+///
+/// ```mbt check
+/// test {
+///   let sub = (a : Int, b : Int) => a - b
+///   assert_eq(sub(3, 10), -7)
+///   assert_eq(flip(sub)(3, 10), 7)
+/// }
+/// ```
 pub fn[M, N, Z] flip(f : (M, N) -> Z) -> (N, M) -> Z {
   (x, y) => f(y, x)
 }

--- a/src/shrink.mbt
+++ b/src/shrink.mbt
@@ -9,6 +9,18 @@
 /// or recursive shrink spaces stay lazy. The default body (`= _`)
 /// means "no shrinks" — a conservative starting point for types where
 /// shrinking isn't meaningful.
+///
+/// ```mbt check
+/// test {
+///   // `Int` has a built-in Shrink instance that walks toward 0.
+///   let candidates : Array[Int] = Shrink::shrink(100).collect()
+///   assert_true(candidates.contains(0))
+///   assert_true(candidates.length() > 0)
+///   // `Bool` shrinks `true` to `false`, and `false` has no shrinks.
+///   assert_eq(Shrink::shrink(true).collect(), [false])
+///   assert_eq(Shrink::shrink(false).collect(), [])
+/// }
+/// ```
 pub(open) trait Shrink {
   shrink(Self) -> Iter[Self] = _
 }
@@ -419,6 +431,14 @@ pub impl[T : Shrink] Shrink for List[T] with shrink(xs) {
 
 ///|
 /// Shrink non-empty list without producing the empty list.
+///
+/// ```mbt check
+/// test {
+///   let xs : @list.List[Int] = @list.from_array([5])
+///   // Default list shrink would produce [], which is filtered out here.
+///   assert_true(shrink_non_empty_list(xs).all(ys => !ys.is_empty()))
+/// }
+/// ```
 pub fn[T : Shrink] shrink_non_empty_list(xs : List[T]) -> Iter[List[T]] {
   Shrink::shrink(xs).filter(ys => !ys.is_empty())
 }
@@ -480,6 +500,12 @@ pub impl[X : Shrink] Shrink for Array[X] with shrink(xs) {
 
 ///|
 /// Shrink non-empty array without producing the empty array.
+///
+/// ```mbt check
+/// test {
+///   assert_true(shrink_non_empty_array([1, 2, 3]).all(ys => ys.length() > 0))
+/// }
+/// ```
 pub fn[X : Shrink] shrink_non_empty_array(xs : Array[X]) -> Iter[Array[X]] {
   Shrink::shrink(xs).filter(ys => ys.length() > 0)
 }


### PR DESCRIPTION
## Summary
- Add `test { ... }` blocks inside public function docstrings across `internal/lazy`, `internal/utils`, `internal/rose`, `feat`, `gen`, and `shrink`, so the examples double as compiled, executed documentation.
- Pure documentation: no public API changes (`pkg.generated.mbti` unchanged), no behavior changes.
- Inline test count grows from 252 → 300.

## Test plan
- [x] `moon check`
- [x] `moon test` — 300/300 pass
- [x] `moon fmt`
- [x] `moon info` — no `.mbti` diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
