### PR TITLE
refactor: deprecate @utils.id and inline at call sites

### DIFF
--- a/src/gen/core.mbt
+++ b/src/gen/core.mbt
@@ -120,7 +120,7 @@ pub fn[T, U] Gen::bind(self : Gen[T], f : (T) -> Gen[U]) -> Gen[U] {
 /// outer generator to produce an inner generator, then running the
 /// inner one.
 pub fn[T] Gen::join(self : Gen[Gen[T]]) -> Gen[T] {
-  self.bind(@utils.id)
+  self.bind(x => x)
 }
 
 ///|

--- a/src/gen/moon.pkg
+++ b/src/gen/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/quickcheck/feat" @feat,
-  "moonbitlang/quickcheck/internal/utils" @utils,
   "moonbitlang/core/list",
   "moonbitlang/core/quickcheck" @coreqc,
   "moonbitlang/core/quickcheck/splitmix" @splitmix,

--- a/src/internal/utils/README.mbt.md
+++ b/src/internal/utils/README.mbt.md
@@ -28,19 +28,13 @@ surface area of the main library.
 
 | Name | Signature | Meaning |
 |------|-----------|---------|
-| `id(x)` | `T -> T` | The identity function |
 | `const_(t)(_)` | `T -> U -> T` | Ignore the second argument, return the first |
 | `flip(f)(x, y)` | `((A, B) -> C) -> (B, A) -> C` | Swap argument order |
 
-> `pair_function` is **deprecated** — inline `tuple => f(tuple.0, tuple.1)` at the call site instead.
+> `id` and `pair_function` are **deprecated** — inline `x => x` and
+> `tuple => f(tuple.0, tuple.1)` at the call site instead.
 
 ```mbt check
-///|
-test "id returns its argument" {
-  assert_eq(@utils.id(42), 42)
-  assert_eq(@utils.id("hi"), "hi")
-}
-
 ///|
 test "const_ ignores the second argument" {
   let always_7 : (String) -> Int = @utils.const_(7)

--- a/src/internal/utils/common.mbt
+++ b/src/internal/utils/common.mbt
@@ -151,15 +151,9 @@ pub fn[T] apply_while_array(
 }
 
 ///|
-/// The identity function: returns its argument unchanged. Bound to the
-/// `%identity` intrinsic, so it compiles to a no-op.
-///
-/// ```mbt check
-/// test {
-///   assert_eq(id(42), 42)
-///   assert_eq(id("moon"), "moon")
-/// }
-/// ```
+/// Deprecated. Inline as `x => x` at the call site — the helper is a
+/// no-op that obscures the shape.
+#deprecated("Inline `x => x` at the call site")
 pub fn[T] id(x : T) -> T = "%identity"
 
 ///|

--- a/src/internal/utils/pkg.generated.mbti
+++ b/src/internal/utils/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub fn[M, N, Z] flip((M, N) -> Z) -> (N, M) -> Z
 
 pub fn fresh_name() -> String
 
+#deprecated
 pub fn[T] id(T) -> T
 
 #deprecated


### PR DESCRIPTION
## Summary
- Mirror the `@utils.pair_function` deprecation (`88ec338`): mark `@utils.id` `#deprecated` with the message `Inline \`x => x\` at the call site`.
- Replace the sole non-doc caller (`Gen::join` in `src/gen/gen.mbt`) with `x => x`.
- Drop the now-unused `@utils` import alias from `src/gen/moon.pkg`.
- Remove the `id` docstring/README test blocks and extend the README deprecation note to mention `id` alongside `pair_function`.

## Test plan
- [x] `moon check` — clean, no warnings
- [x] `moon test` — 304/304 pass
- [x] `moon info` — only expected `#deprecated` marker added to `src/internal/utils/pkg.generated.mbti`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
