### PR TITLE
refactor: drop package-local `using` re-exports

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -519,7 +519,7 @@ fn State::run_single_test(
 fn State::find_failure(
   self : State,
   res : SingleResult,
-  ts : Iter[Rose[SingleResult]],
+  ts : Iter[@rose.Rose[SingleResult]],
 ) -> TestSuccess raise TestError {
   let (n, tf, lf, ce) = { ..self, num_try_shrinks: 0 }.local_min(res, ts)
   self.callback_post_final_failure(ce)
@@ -592,7 +592,7 @@ fn State::find_failure_no_shrink(
 fn State::local_min(
   self : State,
   res : SingleResult,
-  ts : Iter[Rose[SingleResult]],
+  ts : Iter[@rose.Rose[SingleResult]],
 ) -> (Int, Int, Int, SingleResult) {
   if self.num_success_shrinks + self.num_to_try_shrinks >= self.max_shrinks_ {
     local_min_found(self, res)

--- a/src/gen/core.mbt
+++ b/src/gen/core.mbt
@@ -2,9 +2,6 @@
 pub using @splitmix {type RandomState}
 
 ///|
-using @list {type List}
-
-///|
 /// The Gen type represents a generator of values of type T.
 pub struct Gen[T] {
   priv gen : (Int, RandomState) -> T
@@ -435,7 +432,7 @@ pub fn[T] frequency(arr : Array[(UInt, Gen[T])]) -> Gen[T] {
 ///|
 /// Chooses one of the given generators, with a weighted random distribution.
 /// @alert unsafe "Panics if the list is empty or total weight is zero"
-pub fn[T] frequency_list(lst : List[(UInt, T)]) -> Gen[T] {
+pub fn[T] frequency_list(lst : @list.List[(UInt, T)]) -> Gen[T] {
   // Single-pass build instead of `.to_array().map(...)` (two arrays).
   let arr : Array[(UInt, Gen[T])] = []
   for pair in lst {
@@ -447,10 +444,10 @@ pub fn[T] frequency_list(lst : List[(UInt, T)]) -> Gen[T] {
 
 ///|
 /// Generate a list of elements from individual generators
-pub fn[T] flatten_list(lst : List[Gen[T]]) -> Gen[List[T]] {
+pub fn[T] flatten_list(lst : @list.List[Gen[T]]) -> Gen[@list.List[T]] {
   match lst {
     Empty => pure(@list.empty())
-    More(x, tail=xs) => liftA2(List::add, flatten_list(xs), x)
+    More(x, tail=xs) => liftA2(@list.List::add, flatten_list(xs), x)
   }
 }
 
@@ -497,7 +494,7 @@ pub fn[T] one_of(arr : Array[Gen[T]]) -> Gen[T] {
 ///|
 /// Randomly uses one of the given generators in list
 /// @alert unsafe "Panics if the list is empty"
-pub fn[T] one_of_list(lst : List[T]) -> Gen[T] {
+pub fn[T] one_of_list(lst : @list.List[T]) -> Gen[T] {
   int_bound(lst.length()).fmap(x => lst.unsafe_nth(x))
 }
 
@@ -621,12 +618,12 @@ pub fn char_range(lo : Char, hi : Char) -> Gen[Char] {
 ///   inspect(g.sample(), content="@list.from_array([42, 42, 42])")
 /// }
 /// ```
-pub fn[T] Gen::list_with_size(gen : Gen[T], size : Int) -> Gen[List[T]] {
+pub fn[T] Gen::list_with_size(gen : Gen[T], size : Int) -> Gen[@list.List[T]] {
   for n = size, acc = pure(@list.empty()) {
     if n <= 0 {
       break acc
     } else {
-      continue n - 1, liftA2(List::add, acc, gen)
+      continue n - 1, liftA2(@list.List::add, acc, gen)
     }
   }
 }
@@ -634,8 +631,8 @@ pub fn[T] Gen::list_with_size(gen : Gen[T], size : Int) -> Gen[List[T]] {
 ///|
 /// Generate a sorted `List[T]` of exactly `size` elements — draws
 /// `size` independent values from `gen`, then sorts.
-pub fn[T : Compare] sorted_list(size : Int, gen : Gen[T]) -> Gen[List[T]] {
-  gen.list_with_size(size).fmap(List::sort)
+pub fn[T : Compare] sorted_list(size : Int, gen : Gen[T]) -> Gen[@list.List[T]] {
+  gen.list_with_size(size).fmap(@list.List::sort)
 }
 
 ///|

--- a/src/gen/core.mbt
+++ b/src/gen/core.mbt
@@ -120,7 +120,7 @@ pub fn[T, U] Gen::bind(self : Gen[T], f : (T) -> Gen[U]) -> Gen[U] {
 /// outer generator to produce an inner generator, then running the
 /// inner one.
 pub fn[T] Gen::join(self : Gen[Gen[T]]) -> Gen[T] {
-  self.bind(@utils.id)
+  self.bind(x => x)
 }
 
 ///|

--- a/src/gen/moon.pkg
+++ b/src/gen/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "moonbitlang/quickcheck/feat" @feat,
-  "moonbitlang/quickcheck/internal/utils" @utils,
   "moonbitlang/core/list",
   "moonbitlang/core/quickcheck" @coreqc,
   "moonbitlang/core/quickcheck/splitmix" @splitmix,

--- a/src/internal/testing/axiom.mbt
+++ b/src/internal/testing/axiom.mbt
@@ -1,7 +1,7 @@
 ///|
 struct Queue {
-  f : List[Int]
-  r : List[Int]
+  f : @list.List[Int]
+  r : @list.List[Int]
 }
 
 ///|
@@ -17,7 +17,7 @@ impl Show for Queue with output(self, logger) {
 impl @qc.Shrink for Queue
 
 ///|
-fn build_queue(f : List[Int], r : List[Int]) -> Queue {
+fn build_queue(f : @list.List[Int], r : @list.List[Int]) -> Queue {
   match f {
     Empty => { f: r, r: @list.empty() }
     f => { f, r }
@@ -59,7 +59,7 @@ fn Queue::dequeue(self : Queue) -> Queue {
 }
 
 ///|
-fn Queue::to_list(self : Queue) -> List[Int] {
+fn Queue::to_list(self : Queue) -> @list.List[Int] {
   self.f.concat(self.r.rev())
 }
 
@@ -70,8 +70,8 @@ fn Queue::op_equal(self : Queue, other : Queue) -> Bool {
 
 ///|
 impl @coreqc.Arbitrary for Queue with arbitrary(i, rs) {
-  let f : List[Int] = @coreqc.Arbitrary::arbitrary(i, rs)
-  let r : List[Int] = @coreqc.Arbitrary::arbitrary(i, rs)
+  let f : @list.List[Int] = @coreqc.Arbitrary::arbitrary(i, rs)
+  let r : @list.List[Int] = @coreqc.Arbitrary::arbitrary(i, rs)
   build_queue(f, r)
 }
 
@@ -88,17 +88,17 @@ impl @qc.Shrink for EqQueue
 
 ///|
 impl @coreqc.Arbitrary for EqQueue with arbitrary(i, rs) {
-  fn split(xs : List[Int], i) {
+  fn split(xs : @list.List[Int], i) {
     (xs.take(i), xs.drop(i))
   }
 
-  fn from(xs : List[Int]) {
+  fn from(xs : @list.List[Int]) {
     let n = @gen.int_bound(xs.length() - 1).run(i, rs)
     let (xs1, xs2) = split(xs, n)
     build_queue(xs1, xs2.rev())
   }
 
-  let z : List[Int] = @coreqc.Arbitrary::arbitrary(i, rs)
+  let z : @list.List[Int] = @coreqc.Arbitrary::arbitrary(i, rs)
   let lhs = from(z)
   let rhs = from(z)
   EqQueue({ lhs, rhs })

--- a/src/internal/testing/driver.mbt
+++ b/src/internal/testing/driver.mbt
@@ -1,7 +1,4 @@
 ///|
-using @list {type List}
-
-///|
 fn add_comm_double(xy : (Double, Double)) -> Bool {
   let (x, y) = xy
   x + y == y + x
@@ -14,13 +11,13 @@ fn add_assoc_double(xyz : (Double, Double, Double)) -> Bool {
 }
 
 ///|
-fn prop_rev(l : List[Int]) -> Bool {
+fn prop_rev(l : @list.List[Int]) -> Bool {
   l.rev().rev() == l
 }
 
 ///|
 test "prop reverse (fail)" {
-  let prop_rev = (l : List[Int]) => l.rev().rev() == l.rev()
+  let prop_rev = (l : @list.List[Int]) => l.rev().rev() == l.rev()
   inspect(
     @qc.quick_check_silence(prop_rev |> @qc.Arrow, expect=Fail),
     content="+++ [9/0/100] Ok! Failed as expected.",
@@ -95,7 +92,7 @@ test "small check expect fail" {
 
 ///|
 test "non empty list (with filter)" {
-  let prop_is_non_empty = (l : List[Int]) => {
+  let prop_is_non_empty = (l : @list.List[Int]) => {
     (!l.is_empty()) |> @qc.filter(!l.is_empty())
   }
   inspect(
@@ -115,10 +112,10 @@ test "reject all" {
 
 ///|
 test "label" {
-  let ar : @qc.Arrow[List[Int], Bool] = Arrow(prop_rev)
+  let ar : @qc.Arrow[@list.List[Int], Bool] = Arrow(prop_rev)
   inspect(
     @qc.quick_check_silence(
-      @qc.Arrow((x : List[Int]) => {
+      @qc.Arrow((x : @list.List[Int]) => {
         @qc.label(ar, if x.is_empty() { "trivial" } else { "non-trivial" })
       }),
     ),
@@ -160,7 +157,7 @@ test "nested arrow uses fresh sample" {
 test "classes" {
   inspect(
     @qc.quick_check_silence(
-      @qc.Arrow((x : List[Int]) => {
+      @qc.Arrow((x : @list.List[Int]) => {
         prop_rev(x)
         |> @qc.classify(x.length() > 5, "long list")
         |> @qc.classify(x.length() <= 5, "short list")
@@ -515,7 +512,7 @@ test "use one_of" {
 test "explicit universal qualification" {
   inspect(
     @qc.quick_check_silence(
-      @qc.forall(@gen.Gen::spawn(), (x : List[Int]) => x.rev().rev() == x),
+      @qc.forall(@gen.Gen::spawn(), (x : @list.List[Int]) => x.rev().rev() == x),
     ),
     content="+++ [100/0/100] Ok, passed!",
   )

--- a/src/internal/testing/feat.mbt
+++ b/src/internal/testing/feat.mbt
@@ -97,7 +97,7 @@ priv enum Tree[T] {
 
 ///|
 priv struct Forest[T] {
-  forest : List[Tree[T]]
+  forest : @list.List[Tree[T]]
 }
 
 ///|

--- a/src/internal/testing/tutorial_en/README.mbt.md
+++ b/src/internal/testing/tutorial_en/README.mbt.md
@@ -530,10 +530,9 @@ QuickCheck defines default test data generators and shrinkers for some often use
 
 ```mbt check
 ///|
-using @list {type List}
-
-///|
-let prop_rev : (List[Int]) -> Bool = (x : List[Int]) => x.rev().rev() == x
+let prop_rev : (@list.List[Int]) -> Bool = (x : @list.List[Int]) => {
+  x.rev().rev() == x
+}
 
 ///|
 test "List reverse" {
@@ -618,7 +617,7 @@ We may also be interested in the distribution of the generated data: sometimes t
 ```mbt check
 ///|
 test "classes" {
-  @qc.quick_check_fn((x : List[Int]) => {
+  @qc.quick_check_fn((x : @list.List[Int]) => {
     prop_rev(x)
     |> @qc.classify(x.length() > 5, "long list")
     |> @qc.classify(x.length() <= 5, "short list")
@@ -641,7 +640,7 @@ The `label` function takes a string and classifies the test case with the string
 ```mbt check
 ///|
 test "label" {
-  @qc.quick_check_fn((x : List[Int]) => {
+  @qc.quick_check_fn((x : @list.List[Int]) => {
     prop_rev(x)
     |> @qc.label(if x.is_empty() { "trivial" } else { "non-trivial" })
   })

--- a/src/internal/utils/README.mbt.md
+++ b/src/internal/utils/README.mbt.md
@@ -28,19 +28,13 @@ surface area of the main library.
 
 | Name | Signature | Meaning |
 |------|-----------|---------|
-| `id(x)` | `T -> T` | The identity function |
 | `const_(t)(_)` | `T -> U -> T` | Ignore the second argument, return the first |
 | `flip(f)(x, y)` | `((A, B) -> C) -> (B, A) -> C` | Swap argument order |
 
-> `pair_function` is **deprecated** — inline `tuple => f(tuple.0, tuple.1)` at the call site instead.
+> `id` and `pair_function` are **deprecated** — inline `x => x` and
+> `tuple => f(tuple.0, tuple.1)` at the call site instead.
 
 ```mbt check
-///|
-test "id returns its argument" {
-  assert_eq(@utils.id(42), 42)
-  assert_eq(@utils.id("hi"), "hi")
-}
-
 ///|
 test "const_ ignores the second argument" {
   let always_7 : (String) -> Int = @utils.const_(7)

--- a/src/internal/utils/common.mbt
+++ b/src/internal/utils/common.mbt
@@ -151,15 +151,9 @@ pub fn[T] apply_while_array(
 }
 
 ///|
-/// The identity function: returns its argument unchanged. Bound to the
-/// `%identity` intrinsic, so it compiles to a no-op.
-///
-/// ```mbt check
-/// test {
-///   assert_eq(id(42), 42)
-///   assert_eq(id("moon"), "moon")
-/// }
-/// ```
+/// Deprecated. Inline as `x => x` at the call site — the helper is a
+/// no-op that obscures the shape.
+#deprecated("Inline `x => x` at the call site")
 pub fn[T] id(x : T) -> T = "%identity"
 
 ///|

--- a/src/internal/utils/pkg.generated.mbti
+++ b/src/internal/utils/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub fn[M, N, Z] flip((M, N) -> Z) -> (N, M) -> Z
 
 pub fn fresh_name() -> String
 
+#deprecated
 pub fn[T] id(T) -> T
 
 #deprecated

--- a/src/result.mbt
+++ b/src/result.mbt
@@ -6,7 +6,7 @@
 /// that a failing test can be rerun deterministically. Typically used
 /// inside the driver — the `Replay` record also surfaces in the
 /// counter-example reported by a failing check.
-pub fn Replay::new(rand_state : RandomState, size : Int) -> Replay {
+pub fn Replay::new(rand_state : @gen.RandomState, size : Int) -> Replay {
   { rand_state, size }
 }
 
@@ -27,12 +27,12 @@ priv struct SingleResult {
   maybe_discarded_ratio : Int?
   maybe_max_shrinks : Int?
   maybe_max_test_size : Int?
-  labels : List[String]
-  classes : List[(String, Bool)]
-  tables : List[(String, String)]
-  test_case : List[String]
+  labels : @list.List[String]
+  classes : @list.List[(String, Bool)]
+  tables : @list.List[(String, String)]
+  test_case : @list.List[String]
   error : Error
-  callbacks : List[Callback]
+  callbacks : @list.List[Callback]
 }
 
 ///|

--- a/src/shrink.mbt
+++ b/src/shrink.mbt
@@ -314,10 +314,10 @@ pub fn[T : Shrink + Compare] shrink_sorted_array(
 ///|
 /// Shrink sorted list, requires the List[T] to be sorted.
 pub fn[T : Shrink + Compare] shrink_sorted_list(
-  xs : List[T],
+  xs : @list.List[T],
   lo~ : T,
   hi~ : T,
-) -> Iter[List[T]] {
+) -> Iter[@list.List[T]] {
   shrink_sorted_array(xs.to_array(), lo~, hi~).map(a => @list.from_array(a))
 }
 
@@ -410,9 +410,9 @@ test "shrink 6-tuple" {
 }
 
 ///|
-pub impl[T : Shrink] Shrink for List[T] with shrink(xs) {
+pub impl[T : Shrink] Shrink for @list.List[T] with shrink(xs) {
   let n = xs.length()
-  fn shr_sub_terms(lst : List[T]) {
+  fn shr_sub_terms(lst : @list.List[T]) {
     match lst {
       Empty => Iter::empty()
       More(x, tail=xs) =>
@@ -439,13 +439,15 @@ pub impl[T : Shrink] Shrink for List[T] with shrink(xs) {
 ///   assert_true(shrink_non_empty_list(xs).all(ys => !ys.is_empty()))
 /// }
 /// ```
-pub fn[T : Shrink] shrink_non_empty_list(xs : List[T]) -> Iter[List[T]] {
+pub fn[T : Shrink] shrink_non_empty_list(
+  xs : @list.List[T],
+) -> Iter[@list.List[T]] {
   Shrink::shrink(xs).filter(ys => !ys.is_empty())
 }
 
 ///|
 test "shrink int list" {
-  let il : List[Int] = @list.from_array([1, 2, 3, 4, 5, 6])
+  let il : @list.List[Int] = @list.from_array([1, 2, 3, 4, 5, 6])
   let s = Shrink::shrink(il)
   json_inspect(s, content=[
     [2, 3, 4, 5, 6],
@@ -473,7 +475,7 @@ test "shrink int list" {
 
 ///|
 test "shrink non-empty list" {
-  let il : List[Int] = @list.from_array([1])
+  let il : @list.List[Int] = @list.from_array([1])
   json_inspect(shrink_non_empty_list(il), content=[[0]])
 }
 
@@ -641,7 +643,7 @@ test "shrink sorted distinct array" {
 
 ///|
 test "shrink sorted list" {
-  let xs : List[Int] = @list.from_array([1, 3, 5])
+  let xs : @list.List[Int] = @list.from_array([1, 3, 5])
   json_inspect(shrink_sorted_list(xs, lo=0, hi=9), content=[
     [3, 5],
     [1, 5],

--- a/src/state.mbt
+++ b/src/state.mbt
@@ -1,7 +1,4 @@
 ///|
-using @list {type List}
-
-///|
 /// Internal State of Compiler
 priv struct State {
   // Name of the test
@@ -32,7 +29,7 @@ priv struct State {
   // Expected result of the test
   mut expected : Expected
   // Current random state
-  mut random_state : RandomState
+  mut random_state : @gen.RandomState
   // Number of successful shrinks
   mut num_success_shrinks : Int
   // Number of shrinks tried since last successful shrink
@@ -172,7 +169,7 @@ fn State::counts(self : State) -> String {
 }
 
 ///|
-priv struct ListCompare[T](List[T]) derive(Eq)
+priv struct ListCompare[T](@list.List[T]) derive(Eq)
 
 ///|
 impl[T : Compare] Compare for ListCompare[T] with compare(self, other) {
@@ -208,7 +205,7 @@ fn Coverage::new() -> Coverage {
 }
 
 ///|
-fn Coverage::label_incr(self : Coverage, key : List[String]) -> Unit {
+fn Coverage::label_incr(self : Coverage, key : @list.List[String]) -> Unit {
   match self.labels.get(key) {
     Some(x) => self.labels[key] = x + 1
     None => self.labels[key] = 1
@@ -218,7 +215,7 @@ fn Coverage::label_incr(self : Coverage, key : List[String]) -> Unit {
 ///|
 fn Coverage::class_incr(
   self : Coverage,
-  classes : List[(String, Bool)],
+  classes : @list.List[(String, Bool)],
 ) -> Unit {
   classes.each(item => {
     let (s, b) = item
@@ -292,7 +289,7 @@ fn Coverage::to_string(self : Coverage, success : Int) -> String {
 ///|
 /// Internal configuration for initializing a test runner.
 priv struct Config {
-  replay : (RandomState, Int)?
+  replay : (@gen.RandomState, Int)?
   max_success : Int
   max_discard_ratio : Int
   max_size : Int

--- a/src/testable.mbt
+++ b/src/testable.mbt
@@ -7,13 +7,7 @@ priv suberror InternalError {
 // The `Testable` impls for them live further down in this file.
 
 ///|
-type RoseRes = Rose[SingleResult]
-
-///|
-using @rose {type Rose}
-
-///|
-using @gen {type Gen, pure}
+type RoseRes = @rose.Rose[SingleResult]
 
 ///|
 /// TODO: determine the execution of callback by kind
@@ -29,12 +23,12 @@ priv enum Kind {
 }
 
 ///|
-fn[T] promote_rose(s : Rose[Gen[T]]) -> Gen[Rose[T]] {
-  Gen((n, rs) => (g : Gen[T]) => g.run(n, rs)).fmap(m => s.fmap(m))
+fn[T] promote_rose(s : @rose.Rose[@gen.Gen[T]]) -> @gen.Gen[@rose.Rose[T]] {
+  @gen.Gen((n, rs) => (g : @gen.Gen[T]) => g.run(n, rs)).fmap(m => s.fmap(m))
 }
 
 ///|
-struct Property(Gen[RoseRes])
+struct Property(@gen.Gen[RoseRes])
 
 ///|
 /// Anything that can be handed to the `quick_check` driver.
@@ -71,7 +65,7 @@ pub impl Testable for Unit with property(_self) {
 
 ///|
 impl Testable for SingleResult with property(self) {
-  pure(@rose.pure(self))
+  @gen.pure(@rose.pure(self))
 }
 
 ///|
@@ -83,7 +77,7 @@ pub impl Testable for Bool with property(self) {
 }
 
 ///|
-pub impl[P : Testable] Testable for Gen[P] with property(self) {
+pub impl[P : Testable] Testable for @gen.Gen[P] with property(self) {
   self.bind(run_prop)
 }
 
@@ -108,7 +102,7 @@ pub impl[P : Testable, A : @coreqc.Arbitrary + Shrink + Show] Testable for Arrow
   A,
   P,
 ] with property(self) {
-  forall_shrink(Gen::spawn(), A::shrink, self.0)
+  forall_shrink(@gen.Gen::spawn(), A::shrink, self.0)
 }
 
 ///|
@@ -118,14 +112,14 @@ pub impl[P : Testable, A : @coreqc.Arbitrary + Shrink + Show] Testable for Arrow
   A,
   P,
 ] with property(self) {
-  forall_shrink(Gen::spawn(), A::shrink, (a : A) => try? (self.0)(a))
+  forall_shrink(@gen.Gen::spawn(), A::shrink, (a : A) => try? (self.0)(a))
 }
 
 ///|
-/// Project a `Testable` to its underlying `Gen[Rose[SingleResult]]`.
+/// Project a `Testable` to its underlying `@gen.Gen[Rose[SingleResult]]`.
 /// Primarily used by other combinators that want to thread extra
 /// transformations through the property.
-fn[P : Testable] run_prop(prop : P) -> Gen[Rose[SingleResult]] {
+fn[P : Testable] run_prop(prop : P) -> @gen.Gen[@rose.Rose[SingleResult]] {
   prop.property().0
 }
 
@@ -158,8 +152,8 @@ pub fn[P : Testable, T] shrinking(
   x0 : T,
   pf : (T) -> P,
 ) -> Property {
-  fn props(x) -> Rose[Gen[RoseRes]] {
-    Rose(pf(x) |> run_prop, shrinker(x).map(props))
+  fn props(x) -> @rose.Rose[@gen.Gen[RoseRes]] {
+    { val: pf(x) |> run_prop, branch: shrinker(x).map(props) }
   }
 
   promote_rose(props(x0)).fmap(x => x.join())
@@ -209,7 +203,10 @@ pub fn[P : Testable] filter(p : P, cond : Bool) -> Property {
 
 ///|
 /// Run with an explicit generator
-pub fn[T : Testable, A : Show] forall(gen : Gen[A], f : (A) -> T) -> Property {
+pub fn[T : Testable, A : Show] forall(
+  gen : @gen.Gen[A],
+  f : (A) -> T,
+) -> Property {
   forall_shrink(gen, _x => Iter::empty(), f)
 }
 
@@ -219,7 +216,7 @@ pub fn[T : Testable, A : Show] forall(gen : Gen[A], f : (A) -> T) -> Property {
 /// version when you want a hand-rolled shrinker without going through
 /// the `Shrink` trait.
 pub fn[T : Testable, A : Show] forall_shrink(
-  gen : Gen[A],
+  gen : @gen.Gen[A],
   shrinker : (A) -> Iter[A],
   f : (A) -> T,
 ) -> Property {

--- a/src/types.mbt
+++ b/src/types.mbt
@@ -16,8 +16,6 @@
 // Generator APIs now live in the dedicated `moonbitlang/quickcheck/gen`
 // package. The root package keeps property DSL and driver types only.
 
-///|
-using @gen {type RandomState}
 // -----------------------------------------------------------------------
 
 ///|
@@ -63,7 +61,7 @@ pub(all) enum Expected {
 ///
 /// Constructor: `Replay::new(rand_state, size)` (see `result.mbt`).
 pub(all) struct Replay {
-  rand_state : RandomState
+  rand_state : @gen.RandomState
   size : Int
 }
 


### PR DESCRIPTION
## Summary
Remove the six file-scoped `using @pkg {...}` re-exports that silently shadowed types as unqualified names inside a package, and spell the qualified path (`@gen.Gen`, `@gen.RandomState`, `@gen.pure`, `@list.List`, `@rose.Rose`) at every use site.

Also tweaks the one lingering `Rose(val, branch)` primary-constructor call to record-literal form (`{ val, branch }`) to avoid the redundant `@rose.` annotation the strict package warnings flag.

Removed declarations:
- `src/testable.mbt`: `using @rose {type Rose}`, `using @gen {type Gen, pure}`
- `src/types.mbt`: `using @gen {type RandomState}`
- `src/state.mbt`: `using @list {type List}`
- `src/gen/core.mbt`: `using @list {type List}`
- `src/internal/testing/driver.mbt`: `using @list {type List}`
- `src/internal/testing/tutorial_en/README.mbt.md`: same inside a tutorial doctest

`pub using` re-exports (public API surface) are intentionally kept.

> Stacks on top of #102 — when that lands this PR will auto-retarget to `main`.

## Test plan
- [x] `moon check` — no warnings
- [x] `moon test` — 304/304 pass
- [x] `moon fmt` — no-op after edits
- [x] `moon info` — no `.mbti` diff (only non-public `using` was removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
