### PR TITLE
fix(gen): drop unnecessary `[:]` view conversions in pick tests

### DIFF
--- a/src/gen/core.mbt
+++ b/src/gen/core.mbt
@@ -666,7 +666,7 @@ test "pick selects first element when weight < first k" {
     (2, pure(20)),
     (3, pure(30)),
   ]
-  let (k, _g) = pick(pure(-1), gs[:], 0)
+  let (k, _g) = pick(pure(-1), gs, 0)
   assert_eq(k, 1)
 }
 
@@ -678,21 +678,21 @@ test "pick selects last element at upper boundary" {
     (3, pure(30)),
   ]
   // 0, 1, 2 exhaust the first two; 3 lands in the third (card 3).
-  let (k, _g) = pick(pure(-1), gs[:], 3)
+  let (k, _g) = pick(pure(-1), gs, 3)
   assert_eq(k, 3)
 }
 
 ///|
 test "pick falls through to default when weight exceeds total" {
   let gs : Array[(UInt, Gen[Int])] = [(1, pure(10)), (2, pure(20))]
-  let (k, _g) = pick(pure(-1), gs[:], 100)
+  let (k, _g) = pick(pure(-1), gs, 100)
   assert_eq(k, 0)
 }
 
 ///|
 test "pick on empty view returns default with zero weight" {
   let gs : Array[(UInt, Gen[Int])] = []
-  let (k, _g) = pick(pure(-1), gs[:], 0)
+  let (k, _g) = pick(pure(-1), gs, 0)
   assert_eq(k, 0)
 }
 


### PR DESCRIPTION
## Summary
- `moon check` was emitting four `unnecessary_view_op` warnings (W0075) in `src/gen/core.mbt`
- MoonBit auto-inserts the view conversion when the expected type is a view, so `gs[:]` is redundant in the `pick(...)` test call sites

## Test plan
- [x] `moon check` — no warnings
- [x] `moon check --target all` — clean across all targets
- [x] `moon test` — 304/304 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
