### PR TITLE
refactor: rename `::new` constructors to primary-constructor form

### DIFF
--- a/src/gen/core.mbt
+++ b/src/gen/core.mbt
@@ -3,17 +3,15 @@ pub using @splitmix {type RandomState}
 
 ///|
 /// The Gen type represents a generator of values of type T.
-pub struct Gen[T] {
-  priv gen : (Int, RandomState) -> T
-
-  fn[T] new(gen : (Int, RandomState) -> T) -> Gen[T]
+struct Gen[T] {
+  gen : (Int, RandomState) -> T
 }
 
 ///|
 /// Build a `Gen[T]` from a `(size, rng) -> T` function. In most cases
 /// you can use the primary constructor syntax `Gen(f)` instead — both
 /// produce an identical generator.
-pub fn[T] Gen::new(gen : (Int, RandomState) -> T) -> Gen[T] {
+pub fn[T] Gen::Gen(gen : (Int, RandomState) -> T) -> Gen[T] {
   { gen, }
 }
 

--- a/src/gen/pkg.generated.mbti
+++ b/src/gen/pkg.generated.mbti
@@ -77,9 +77,8 @@ pub fn[T, U] tuple(Gen[T], Gen[U]) -> Gen[(T, U)]
 // Types and methods
 pub struct Gen[T] {
   // private fields
-
-  fn[T] new((Int, @splitmix.RandomState) -> T) -> Gen[T]
 }
+pub fn[T] Gen::Gen((Int, @splitmix.RandomState) -> T) -> Self[T]
 pub fn[T, U] Gen::ap(Self[(T) -> U], Self[T]) -> Self[U]
 pub fn[T] Gen::array_with_size(Self[T], Int) -> Self[Array[T]]
 pub fn[T, U] Gen::bind(Self[T], (T) -> Self[U]) -> Self[U]
@@ -87,7 +86,6 @@ pub fn[T : @feat.Enumerable] Gen::feat_random(Int) -> Self[T]
 pub fn[T, U] Gen::fmap(Self[T], (T) -> U) -> Self[U]
 pub fn[T] Gen::join(Self[Self[T]]) -> Self[T]
 pub fn[T] Gen::list_with_size(Self[T], Int) -> Self[@list.List[T]]
-pub fn[T] Gen::new((Int, @splitmix.RandomState) -> T) -> Self[T]
 pub fn[T] Gen::resize(Self[T], Int) -> Self[T]
 pub fn[T] Gen::run(Self[T], Int, @splitmix.RandomState) -> T
 pub fn[T] Gen::sample(Self[T], size? : Int, seed? : UInt64) -> T

--- a/src/internal/rose/pkg.generated.mbti
+++ b/src/internal/rose/pkg.generated.mbti
@@ -14,16 +14,14 @@ pub fn[T] pure(T) -> Rose[T]
 pub(all) struct Rose[T] {
   val : T
   branch : Iter[Rose[T]]
-
-  fn[T] new(T, Iter[Rose[T]]) -> Rose[T]
 } derive(@debug.Debug)
+#as_free_fn(deprecated)
+pub fn[T] Rose::Rose(T, Iter[Self[T]]) -> Self[T]
 pub fn[T] Rose::apply(Self[T], (T, Iter[Self[T]]) -> Self[T]) -> Self[T]
 pub fn[T, U] Rose::bind(Self[T], (T) -> Self[U]) -> Self[U]
 pub fn[T, U] Rose::fmap(Self[T], (T) -> U) -> Self[U]
 pub fn[T] Rose::iter(Self[T]) -> Iter[T]
 pub fn[T] Rose::join(Self[Self[T]]) -> Self[T]
-#as_free_fn(deprecated)
-pub fn[T] Rose::new(T, Iter[Self[T]]) -> Self[T]
 
 // Type aliases
 

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -17,8 +17,6 @@
 pub(all) struct Rose[T] {
   val : T
   branch : Iter[Rose[T]]
-
-  fn[T] new(val : T, branch : Iter[Rose[T]]) -> Rose[T]
 } derive(Debug)
 
 ///|
@@ -26,7 +24,7 @@ pub(all) struct Rose[T] {
 /// Kept for backward compatibility with callers that predate the
 /// primary-constructor migration.
 #as_free_fn(deprecated="Use Rose(...) directly")
-pub fn[T] Rose::new(val : T, branch : Iter[Rose[T]]) -> Rose[T] {
+pub fn[T] Rose::Rose(val : T, branch : Iter[Rose[T]]) -> Rose[T] {
   { val, branch }
 }
 


### PR DESCRIPTION
Rename `Gen::new` → `Gen::Gen` and `Rose::new` → `Rose::Rose` so callers can use the primary-constructor syntax `Gen(...)` / `Rose(...)` without a separate `::new` alias. Regenerate the `.mbti` files, which also drops stale `Arrow*::inner` entries.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
