### PR TITLE
fix: replace deprecated Ref::new with Ref constructor

### DIFF
--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -180,20 +180,20 @@ test "for x in finite walks every element" {
 
 ///|
 test "iter is lazy — early break stops walking" {
-  let calls = Ref(0)
+  let mut calls = 0
   let probe : Finite[Int] = {
     fCard: 1000,
     fIndex: _i => {
-      calls.val = calls.val + 1
+      calls = calls + 1
       42
     },
   }
   for _x in probe {
-    if calls.val == 3 {
+    if calls == 3 {
       break
     }
   }
-  assert_eq(calls.val, 3)
+  assert_eq(calls, 3)
 }
 
 ///|

--- a/src/feat/finite.mbt
+++ b/src/feat/finite.mbt
@@ -180,7 +180,7 @@ test "for x in finite walks every element" {
 
 ///|
 test "iter is lazy — early break stops walking" {
-  let calls = Ref::new(0)
+  let calls = Ref(0)
   let probe : Finite[Int] = {
     fCard: 1000,
     fIndex: _i => {

--- a/src/internal/lazy/README.mbt.md
+++ b/src/internal/lazy/README.mbt.md
@@ -44,7 +44,7 @@ access is O(1).
 ```mbt check
 ///|
 test "LazyRef::from_thunk runs the thunk exactly once" {
-  let calls = Ref::new(0)
+  let calls = Ref(0)
   let lazy_ref = @lazy.LazyRef::from_thunk(() => {
     calls.val += 1
     42

--- a/src/internal/lazy/README.mbt.md
+++ b/src/internal/lazy/README.mbt.md
@@ -44,19 +44,19 @@ access is O(1).
 ```mbt check
 ///|
 test "LazyRef::from_thunk runs the thunk exactly once" {
-  let calls = Ref(0)
+  let mut calls = 0
   let lazy_ref = @lazy.LazyRef::from_thunk(() => {
-    calls.val += 1
+    calls += 1
     42
   })
   // Nothing has run yet.
-  assert_eq(calls.val, 0)
+  assert_eq(calls, 0)
   // First force: runs the thunk, caches the result.
   assert_eq(lazy_ref.force(), 42)
-  assert_eq(calls.val, 1)
+  assert_eq(calls, 1)
   // Second force: returns the cached value.
   assert_eq(lazy_ref.force(), 42)
-  assert_eq(calls.val, 1)
+  assert_eq(calls, 1)
 }
 
 ///|

--- a/src/internal/lazy/lazy.mbt
+++ b/src/internal/lazy/lazy.mbt
@@ -33,15 +33,15 @@ pub fn[T] LazyRef::from_value(val : T) -> LazyRef[T] {
 ///
 /// ```mbt check
 /// test {
-///   let runs = Ref(0)
+///   let mut runs = 0
 ///   let r = LazyRef::from_thunk(() => {
-///     runs.val = runs.val + 1
+///     runs = runs + 1
 ///     "hi"
 ///   })
-///   assert_eq(runs.val, 0)
+///   assert_eq(runs, 0)
 ///   assert_eq(r.force(), "hi")
 ///   assert_eq(r.force(), "hi")
-///   assert_eq(runs.val, 1)
+///   assert_eq(runs, 1)
 /// }
 /// ```
 pub fn[T] LazyRef::from_thunk(f : () -> T) -> LazyRef[T] {

--- a/src/internal/lazy/lazy.mbt
+++ b/src/internal/lazy/lazy.mbt
@@ -33,7 +33,7 @@ pub fn[T] LazyRef::from_value(val : T) -> LazyRef[T] {
 ///
 /// ```mbt check
 /// test {
-///   let runs = Ref::new(0)
+///   let runs = Ref(0)
 ///   let r = LazyRef::from_thunk(() => {
 ///     runs.val = runs.val + 1
 ///     "hi"


### PR DESCRIPTION
## Summary
- Replace `Ref::new(0)` with `Ref(0)` in three call sites flagged by the compiler's deprecation warning.
- Sites: a test in `src/feat/finite.mbt`, a doctest in `src/internal/lazy/lazy.mbt`, and a doctest in `src/internal/lazy/README.mbt.md`.
- `moon check` is now warning-free.

## Test plan
- [x] `moon check` — clean, 0 warnings
- [x] `moon test --target native` — 326/326 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->