### PR TITLE
refactor(driver): chain CheckReport.render, simplify active_classes

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -63,13 +63,12 @@ pub fn[P : Testable] quick_check_silence(
   verbose? : Bool = false,
 ) -> String {
   let prop = map_total_result(prop, res => { ..res, expect, abort })
-  let report = @report.CheckReport(
+  @report.CheckReport(
     try? quick_check_with_result(
       { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
       prop,
     ),
-  )
-  report.render(verbose~)
+  ).render(verbose~)
 }
 
 ///|
@@ -136,7 +135,7 @@ pub fn[A : @coreqc.Arbitrary + Shrink + Show, B : Testable] quick_check_fn_error
   expect? : Expected = Success,
   abort? : Bool = false,
   verbose? : Bool = false,
-) -> Unit raise Failure {
+) -> Unit raise  {
   quick_check(
     ArrowError(f),
     max_shrink?=max_shrinks,
@@ -218,10 +217,9 @@ pub fn[A : @feat.Enumerable + Show, B : Testable] small_check_silence(
   abort? : Bool = false,
   verbose? : Bool = false,
 ) -> String {
-  let report = @report.CheckReport(
-    try? small_check_with_result(f, max_size, expect, abort),
+  @report.CheckReport(try? small_check_with_result(f, max_size, expect, abort)).render(
+    verbose~,
   )
-  report.render(verbose~)
 }
 
 ///|
@@ -331,14 +329,12 @@ fn[A : @feat.Enumerable + Show, B : Testable] small_check_with_result(
 fn active_classes(
   classes : @list.List[(String, Bool)],
 ) -> @sorted_set.SortedSet[String] {
-  let acc : Array[String] = []
-  classes.each(fn(pair) {
-    let (name, active) = pair
-    if active {
-      acc.push(name)
-    }
-  })
-  @sorted_set.from_iter(acc.iter())
+  
+  [
+    for pair in classes if pair.1 => pair.0
+  ] |> @sorted_set.from_array
+  
+
 }
 
 ///|

--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -135,7 +135,7 @@ pub fn[A : @coreqc.Arbitrary + Shrink + Show, B : Testable] quick_check_fn_error
   expect? : Expected = Success,
   abort? : Bool = false,
   verbose? : Bool = false,
-) -> Unit raise  {
+) -> Unit raise Failure {
   quick_check(
     ArrowError(f),
     max_shrink?=max_shrinks,
@@ -329,12 +329,7 @@ fn[A : @feat.Enumerable + Show, B : Testable] small_check_with_result(
 fn active_classes(
   classes : @list.List[(String, Bool)],
 ) -> @sorted_set.SortedSet[String] {
-  
-  [
-    for pair in classes if pair.1 => pair.0
-  ] |> @sorted_set.from_array
-  
-
+  [ for pair in classes if pair.1 => pair.0 ] |> @sorted_set.from_array
 }
 
 ///|

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub fn[P : Testable] quick_check(P, max_shrink? : Int, max_success? : Int, max_s
 
 pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn((A) -> B, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> Unit raise Failure
 
-pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn_error((A) -> B raise, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> Unit raise
+pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn_error((A) -> B raise, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> Unit raise Failure
 
 pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn_error_silence((A) -> B raise, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> String
 

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub fn[P : Testable] quick_check(P, max_shrink? : Int, max_success? : Int, max_s
 
 pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn((A) -> B, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> Unit raise Failure
 
-pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn_error((A) -> B raise, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> Unit raise Failure
+pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn_error((A) -> B raise, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> Unit raise
 
 pub fn[A : @moonbitlang/core/quickcheck.Arbitrary + @shrink.Shrink + Show, B : Testable] quick_check_fn_error_silence((A) -> B raise, max_shrinks? : Int, max_success? : Int, max_size? : Int, discard_ratio? : Int, expect? : @state.Expected, abort? : Bool, verbose? : Bool) -> String
 


### PR DESCRIPTION
## Summary
Two small cleanups in `src/driver.mbt`:

- **`quick_check_silence` / `small_check_silence`**: drop the `let report = ...; report.render(verbose~)` pair and chain `.render()` directly on the `@report.CheckReport(...)` constructor.
- **`active_classes`**: replace the manual `for/each` + `acc.push` accumulator with a for-comprehension piped into `@sorted_set.from_array`.

mbti regen also picks up a minor cosmetic shift in `quick_check_fn_error`'s rendered signature (no semantic change).

## Test plan
- [x] `moon check` clean
- [x] `moon test` — 326 / 326 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->