### PR TITLE
refactor(rose): move test-only-reachable exports into exports.mbt

### DIFF
--- a/src/internal/rose/exports.mbt
+++ b/src/internal/rose/exports.mbt
@@ -1,0 +1,31 @@
+// Public API surface that has no current production callers but is
+// kept exported on purpose — for users of the library and for the
+// `mbt check` examples in `README.mbt.md`. Convention: items that
+// are only reached from tests / docs live here so that grepping
+// `rose.mbt` reflects the genuine in-driver-path code.
+
+///|
+/// Monadic bind: replace each node's value with the tree produced by
+/// `f`. Equivalent to `self.fmap(f).join()`.
+///
+/// ```mbt check
+/// test {
+///   let r = pure(3).bind(x => pure(x * x))
+///   assert_eq(r.iter().collect(), [9])
+/// }
+/// ```
+pub fn[T, U] Rose::bind(self : Rose[T], f : (T) -> Rose[U]) -> Rose[U] {
+  self.fmap(f).join()
+}
+
+///|
+/// Inspect a node — pass its value and its branches to `f` and use
+/// whatever `f` returns as the new node. Essentially a controlled
+/// node-level rewrite; used when a shrinker wants to transform a
+/// rose without descending into every child.
+pub fn[T] Rose::apply(
+  self : Rose[T],
+  f : (T, Iter[Rose[T]]) -> Rose[T],
+) -> Rose[T] {
+  f(self.val, self.branch)
+}

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -80,32 +80,6 @@ pub fn[T, U] Rose::fmap(self : Rose[T], f : (T) -> U) -> Rose[U] {
 }
 
 ///|
-/// Monadic bind: replace each node's value with the tree produced by
-/// `f`. Equivalent to `self.fmap(f).join()`.
-///
-/// ```mbt check
-/// test {
-///   let r = pure(3).bind(x => pure(x * x))
-///   assert_eq(r.iter().collect(), [9])
-/// }
-/// ```
-pub fn[T, U] Rose::bind(self : Rose[T], f : (T) -> Rose[U]) -> Rose[U] {
-  self.fmap(f).join()
-}
-
-///|
-/// Inspect a node — pass its value and its branches to `f` and use
-/// whatever `f` returns as the new node. Essentially a controlled
-/// node-level rewrite; used when a shrinker wants to transform a
-/// rose without descending into every child.
-pub fn[T] Rose::apply(
-  self : Rose[T],
-  f : (T, Iter[Rose[T]]) -> Rose[T],
-) -> Rose[T] {
-  f(self.val, self.branch)
-}
-
-///|
 /// Pre-order traversal: yields the root value, then the values of every
 /// branch depth-first. Enables `for x in rose { ... }` and any other
 /// `Iter`-shaped consumer.


### PR DESCRIPTION
## Summary
Establishes a new convention: items that are publicly exposed but reached only from tests / `README.mbt.md` examples (no in-driver call sites) live in a sibling `exports.mbt` file, so the main implementation file reflects the genuine production-path surface.

For `internal/rose`:
- Move `Rose::apply` (1 test usage from README example) and `Rose::bind` (2 test usages — own doc-test + README) out of `rose.mbt` into a new `exports.mbt`.
- Keep them `pub` — the README's `mbt check` blocks and any future external user keep working.
- `Rose::iter` stays in `rose.mbt`: even though all current callers are tests, iterators are generally useful and underly `for x in rose` syntax (kept per author's call).

## Verification
- mbti is byte-for-byte identical (`pub` surface unchanged)
- `moon check`, `moon test` (326/326), `moon fmt` all clean

## Follow-ups (out of scope here)
The same convention can be applied to other internal packages flagged by `moon ide analyze` (e.g. several `LazyList::*` methods with zero production callers, the entire `internal/shrinking` package). Doing it package-by-package keeps each PR reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->