### PR TITLE
refactor(rose): relocate Rose::iter into exports.mbt

### DIFF
--- a/src/internal/rose/README.mbt.md
+++ b/src/internal/rose/README.mbt.md
@@ -235,11 +235,8 @@ test "iter visits root then branches in DFS order" {
 ///|
 test "for .. in walks every value" {
   let tree = @rose.Rose(10, [@rose.pure(20), @rose.pure(30)].iter())
-  let seen : Array[Int] = []
-  for x in tree {
-    seen.push(x)
-  }
-  assert_eq(seen, [10, 20, 30])
+
+  assert_eq([ for x in tree => x ], [10, 20, 30])
 }
 ```
 

--- a/src/internal/rose/exports.mbt
+++ b/src/internal/rose/exports.mbt
@@ -29,3 +29,16 @@ pub fn[T] Rose::apply(
 ) -> Rose[T] {
   f(self.val, self.branch)
 }
+
+///|
+/// Pre-order traversal: yields the root value, then the values of every
+/// branch depth-first. Enables `for x in rose { ... }` and any other
+/// `Iter`-shaped consumer.
+///
+/// The traversal is lazy: only as many sub-trees as you actually walk
+/// are forced. Note that — like every `Iter` in MoonBit — the result
+/// is single-shot; iterating the same `Rose` twice will only visit the
+/// elements that were not yet consumed by an earlier walk.
+pub fn[T] Rose::iter(self : Rose[T]) -> Iter[T] {
+  Iter::singleton(self.val) + self.branch.flat_map(child => child.iter())
+}

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -80,19 +80,6 @@ pub fn[T, U] Rose::fmap(self : Rose[T], f : (T) -> U) -> Rose[U] {
 }
 
 ///|
-/// Pre-order traversal: yields the root value, then the values of every
-/// branch depth-first. Enables `for x in rose { ... }` and any other
-/// `Iter`-shaped consumer.
-///
-/// The traversal is lazy: only as many sub-trees as you actually walk
-/// are forced. Note that — like every `Iter` in MoonBit — the result
-/// is single-shot; iterating the same `Rose` twice will only visit the
-/// elements that were not yet consumed by an earlier walk.
-pub fn[T] Rose::iter(self : Rose[T]) -> Iter[T] {
-  Iter::singleton(self.val) + self.branch.flat_map(child => child.iter())
-}
-
-///|
 test "iter walks root then branches in depth-first order" {
   // A small handcrafted tree:
   //


### PR DESCRIPTION
## Summary
Follow-up to #117 (now merged) — extends the `exports.mbt` convention to `Rose::iter`.

`Rose::iter` is generally useful (it underlies `for x in rose` syntax) but no current driver-path code calls it directly — all 5 usages are in tests / `README.mbt.md` examples. Per the convention, generally-useful API surface that no driver-path code reaches lives in `exports.mbt`. So move it there from `rose.mbt`.

Also picks up an unrelated README simplification: collapse the `for x in tree { seen.push(x); ... }; assert_eq(seen, ...)` example into `assert_eq([ for x in tree => x ], ...)` using the for-comprehension syntax already used elsewhere in the codebase.

## Verification
- mbti is byte-for-byte identical (`pub` surface unchanged)
- `moon check`, `moon test` (326/326), `moon fmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->