### PR TITLE
refactor(state): use Int::clamp / .min / .max instead of @cmp helpers

### DIFF
--- a/src/internal/state/moon.pkg
+++ b/src/internal/state/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "moonbitlang/quickcheck/gen",
   "moonbitlang/quickcheck/internal/utils",
-  "moonbitlang/core/cmp",
   "moonbitlang/core/list",
   "moonbitlang/core/sorted_map",
   "moonbitlang/core/quickcheck/splitmix",

--- a/src/internal/state/state.mbt
+++ b/src/internal/state/state.mbt
@@ -277,17 +277,17 @@ pub fn State::compute_size(self : State) -> Int {
       num_recent_discarded_tests: d,
       ..,
     } => {
-      fn clamp(x, l, h) {
-        @cmp.maximum(l, @cmp.minimum(x, h))
+      let dDenom = if mdr > 0 {
+        (mss * mdr / 3).clamp(min=1, max=10)
+      } else {
+        1
       }
-
-      let dDenom = if mdr > 0 { clamp(mss * mdr / 3, 1, 10) } else { 1 }
       fn round_to(n, m) {
         n / m * m
       }
 
       if round_to(n, mts) + mts <= mss || n >= mss || mss % mts == 0 {
-        @cmp.minimum(n % mts + d / dDenom, mts)
+        (n % mts + d / dDenom).min(mts)
       } else {
         (n % mts * mts / (mss % mts) + d / dDenom) % mts
       }
@@ -339,7 +339,7 @@ pub fn State::finished_successfully(self : State) -> Bool {
 pub fn State::discarded_too_much(self : State) -> Bool {
   if self.max_discarded_ratio_ > 0 {
     self.num_discarded_tests / self.max_discarded_ratio_ >=
-    @cmp.maximum(self.num_success_tests, self.max_success_tests_)
+    self.num_success_tests.max(self.max_success_tests_)
   } else {
     false
   }

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -7,7 +7,6 @@ import {
   "moonbitlang/quickcheck/internal/state",
   "moonbitlang/quickcheck/internal/report",
   "moonbitlang/core/sorted_set",
-  "moonbitlang/core/cmp",
   "moonbitlang/core/list",
   "moonbitlang/core/quickcheck" @coreqc,
   "moonbitlang/core/buffer",


### PR DESCRIPTION
## Summary
`compute_size` had a hand-rolled `fn clamp(x, l, h) { @cmp.maximum(l, @cmp.minimum(x, h)) }` — exactly `Int::clamp(x, min=l, max=h)` from core. Drop the local helper and the two other `@cmp.minimum` / `@cmp.maximum` call sites in favour of the Int-method forms (`.min`, `.max`, `.clamp`).

After the change `@cmp` is no longer referenced anywhere in the project, so it's removed from `internal/state/moon.pkg` and the root `moon.pkg`.

## Test plan
- [x] `moon check` clean
- [x] `moon test` — 331 / 331
- [x] `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/quickcheck/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->