### PR TITLE
refactor(state): use for-in over List::each in callback dispatchers

### DIFF
--- a/src/internal/state/state.mbt
+++ b/src/internal/state/state.mbt
@@ -350,12 +350,12 @@ pub fn State::discarded_too_much(self : State) -> Bool {
 /// generated sample (success, failure, or discard), before the driver
 /// decides what to do next.
 pub fn State::callback_post_test(self : State, res : SingleResult) -> Unit {
-  res.callbacks.each(cb => {
+  for cb in res.callbacks {
     match cb {
       PostTest(_, f) => f(self, res)
       _ => ()
     }
-  })
+  }
 }
 
 ///|
@@ -367,12 +367,12 @@ pub fn State::callback_post_final_failure(
   self : State,
   res : SingleResult,
 ) -> Unit {
-  res.callbacks.each(cb => {
+  for cb in res.callbacks {
     match cb {
       PostFinalFailure(_, f) => f(self, res)
       _ => ()
     }
-  })
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary
Replace `res.callbacks.each(cb => match cb { ... })` with `for cb in res.callbacks { match cb { ... } }` in `State::callback_post_test` and `State::callback_post_final_failure`. Same semantics, no closure allocation, reads more linearly.

## Test plan
- [x] `moon check` clean
- [x] `moon test` — 331 / 331
- [x] `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)