### PR TITLE
refactor: inline render_coverage, narrow Coverage visibility

### DIFF
--- a/src/internal/report/report.mbt
+++ b/src/internal/report/report.mbt
@@ -71,17 +71,12 @@ fn render_block(title : String, lines : Array[String]) -> String {
 }
 
 ///|
-fn render_coverage(coverage : @state.Coverage, num_tests : Int) -> String {
-  coverage.to_string(num_tests)
-}
-
-///|
 fn render_success(result : TestSuccess) -> String {
   let lines : Array[String] = []
   match result {
     Success(output~, coverage~, num_tests~) => {
       lines.push(output)
-      let rendered = render_coverage(coverage, num_tests)
+      let rendered = coverage.to_string(num_tests)
       if rendered != "" {
         lines.push(rendered)
       }
@@ -127,7 +122,7 @@ fn render_error(error : TestError, verbose : Bool) -> String {
         lines.push(
           "Shrinks: \{num_shrinks} successful, \{num_shrink_tries} unsuccessful, \{num_shrink_final} final attempts",
         )
-        let rendered = render_coverage(coverage, num_tests)
+        let rendered = coverage.to_string(num_tests)
         if rendered != "" {
           lines.push("Coverage:\n\{rendered}")
         }
@@ -135,14 +130,14 @@ fn render_error(error : TestError, verbose : Bool) -> String {
     }
     GaveUp(output~, coverage~, num_tests~, ..) => {
       lines.push(output)
-      let rendered = render_coverage(coverage, num_tests)
+      let rendered = coverage.to_string(num_tests)
       if rendered != "" {
         lines.push(rendered)
       }
     }
     NoneExpectedFail(output~, coverage~, num_tests~, ..) => {
       lines.push(output)
-      let rendered = render_coverage(coverage, num_tests)
+      let rendered = coverage.to_string(num_tests)
       if rendered != "" {
         lines.push(rendered)
       }

--- a/src/internal/state/coverage.mbt
+++ b/src/internal/state/coverage.mbt
@@ -5,7 +5,7 @@
 /// renders the tallies as the percentage lines appended to the
 /// success / failure report; construction and update happen inside
 /// this package.
-pub struct Coverage {
+struct Coverage {
   labels : @sorted_map.SortedMap[@list.List[String], Int]
   classes : @sorted_map.SortedMap[String, Int]
 }
@@ -21,6 +21,7 @@ fn Coverage::new() -> Coverage {
 /// Record one occurrence of the given label stack (as
 /// attached by `label(...)`).
 fn Coverage::label_incr(self : Coverage, key : @list.List[String]) -> Unit {
+  // FIXME(upstream): use self.labels.update_or_init(key, 1, x=> x + 1) once that's available
   self.labels[key] = self.labels.get_or_default(key, 0) + 1
 }
 
@@ -35,6 +36,7 @@ fn Coverage::class_incr(
   for item in classes {
     let (s, b) = item
     let i = if b { 1 } else { 0 }
+    // FIXME(upstream): use self.classes.update_or_init(s, i, x => x + i) once that's available
     self.classes[s] = self.classes.get_or_default(s, 0) + i
   }
 }

--- a/src/internal/state/pkg.generated.mbti
+++ b/src/internal/state/pkg.generated.mbti
@@ -4,7 +4,6 @@ package "moonbitlang/quickcheck/internal/state"
 import {
   "moonbitlang/core/list",
   "moonbitlang/core/quickcheck/splitmix",
-  "moonbitlang/core/sorted_map",
 }
 
 // Values
@@ -31,10 +30,7 @@ pub(all) struct Config {
   max_shrink : Int
 }
 
-pub struct Coverage {
-  labels : @sorted_map.SortedMap[@list.List[String], Int]
-  classes : @sorted_map.SortedMap[String, Int]
-}
+type Coverage
 pub fn Coverage::to_string(Self, Int) -> String
 
 pub(all) enum Expected {


### PR DESCRIPTION
## Summary
Three small report/coverage tidy-ups:

- **`internal/report/report.mbt`**: drop the one-line `render_coverage(coverage, num_tests) = coverage.to_string(num_tests)` wrapper and inline at all four callsites in `render_success` / `render_error`.
- **`internal/state/coverage.mbt`**: narrow `Coverage` from `pub` to package-private — the only externally visible operation is `Coverage::to_string` (still pub).
- **`internal/state/coverage.mbt`**: add `FIXME(upstream)` notes in `label_incr` / `class_incr` flagging that an `update_or_init` method on core's `SortedMap` would collapse the get-then-set into one operation.

## Test plan
- [x] `moon check` clean
- [x] `moon test` — 331 / 331
- [x] `moon fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)