### PR TITLE
Refactor: move shrink tests to blackbox, inline run_test, return CheckReport directly

### DIFF
--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -39,12 +39,9 @@ pub fn[P : Testable] quick_check(
   verbose? : Bool = false,
 ) -> Unit raise Failure {
   let prop = map_total_result(prop, res => { ..res, expect, abort })
-  let report = @report.CheckReport(
-    try? quick_check_with_result(
-      { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
-      prop,
-    ),
-  )
+  let report = @state.from_config(
+    { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
+  ).run_test(prop.property())
   finish_report(report, verbose)
 }
 
@@ -63,12 +60,9 @@ pub fn[P : Testable] quick_check_silence(
   verbose? : Bool = false,
 ) -> String {
   let prop = map_total_result(prop, res => { ..res, expect, abort })
-  @report.CheckReport(
-    try? quick_check_with_result(
-      { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
-      prop,
-    ),
-  ).render(verbose~)
+  @state.from_config(
+    { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
+  ).run_test(prop.property()).render(verbose~)
 }
 
 ///|
@@ -173,15 +167,7 @@ pub fn[A : @coreqc.Arbitrary + Shrink + Show, B : Testable] quick_check_fn_error
   )
 }
 
-///|
-/// Internal helper: run a property with a fully-specified `Config`
-/// and return the structured `TestSuccess` / raise `TestError`.
-fn[P : Testable] quick_check_with_result(
-  cfg : @state.Config,
-  prop : P,
-) -> @report.TestSuccess raise @report.TestError {
-  @state.from_config(cfg).run_test(prop.property())
-}
+
 
 ///|
 /// Exhaustive-ish testing via the `feat` enumeration: walk values of

--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -39,9 +39,12 @@ pub fn[P : Testable] quick_check(
   verbose? : Bool = false,
 ) -> Unit raise Failure {
   let prop = map_total_result(prop, res => { ..res, expect, abort })
-  let report = @state.from_config(
-    { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
-  ).run_test(prop.property())
+  let report = @state.from_config({
+    max_shrink,
+    max_success,
+    max_size,
+    max_discard_ratio: discard_ratio,
+  }).run_test(prop.property())
   finish_report(report, verbose)
 }
 
@@ -60,9 +63,14 @@ pub fn[P : Testable] quick_check_silence(
   verbose? : Bool = false,
 ) -> String {
   let prop = map_total_result(prop, res => { ..res, expect, abort })
-  @state.from_config(
-    { max_shrink, max_success, max_size, max_discard_ratio: discard_ratio },
-  ).run_test(prop.property()).render(verbose~)
+  @state.from_config({
+    max_shrink,
+    max_success,
+    max_size,
+    max_discard_ratio: discard_ratio,
+  })
+  .run_test(prop.property())
+  .render(verbose~)
 }
 
 ///|
@@ -166,8 +174,6 @@ pub fn[A : @coreqc.Arbitrary + Shrink + Show, B : Testable] quick_check_fn_error
     verbose~,
   )
 }
-
-
 
 ///|
 /// Exhaustive-ish testing via the `feat` enumeration: walk values of

--- a/src/driver.mbt
+++ b/src/driver.mbt
@@ -333,30 +333,6 @@ fn active_classes(
 }
 
 ///|
-/// Run the main QuickCheck loop: draw inputs, evaluate the property,
-/// book-keep successes and discards, and on failure hand off to
-/// `find_failure` for shrinking. Returns the aggregated
-/// `TestSuccess` or raises `TestError`.
-fn @state.State::run_test(
-  self : @state.State,
-  prop : Property,
-) -> @report.TestSuccess raise @report.TestError {
-  for cur = self.run_single_test(prop) {
-    match cur {
-      Ok(res) => break res
-      Err(ns) =>
-        if ns.finished_successfully() {
-          break ns.complete_test(prop)
-        } else if ns.discarded_too_much() {
-          break ns.give_up(prop)
-        } else {
-          continue ns.run_single_test(prop)
-        }
-    }
-  }
-}
-
-///|
 /// Wrap up a finished test run — produce the formatted success
 /// report when the expected outcome matches, or raise the
 /// appropriate `TestError` when it does not (e.g. the property was
@@ -402,61 +378,6 @@ fn @state.State::give_up(
       coverage=self.collects,
       output="*** \{self.counts()} Gave up! Passed only \{self.num_success_tests} tests.",
     )
-  }
-}
-
-///|
-/// Run a single test and return the Ok(result) if ended successfully, or Err(state) if it should continue.
-fn @state.State::run_single_test(
-  self : @state.State,
-  prop : Property,
-) -> Result[@report.TestSuccess, @state.State] raise @report.TestError {
-  let rnd1 = self.random_state.split()
-  let rnd2 = self.random_state
-  let { val: res, branch: ts } = prop.0.run(self.compute_size(), rnd1)
-  fn update_state(st0 : @state.State) {
-    self.random_state = rnd2
-    st0.update_state_from_res(res)
-  }
-
-  fn next(
-    end_with : (@state.State, Property) -> @report.TestSuccess raise @report.TestError,
-    next_state : @state.State,
-    p : Property,
-  ) -> Result[@report.TestSuccess, @state.State] raise @report.TestError {
-    update_state(next_state)
-    if res.abort {
-      Ok(end_with(next_state, p))
-    } else {
-      Err(next_state)
-    }
-  }
-
-  let stc = self.clone()
-  stc.add_coverages(res) // The failure should not be counted.
-  self.callback_post_test(res)
-  match res.status {
-    Passed =>
-      next(
-        @state.State::complete_test,
-        {
-          ..stc,
-          num_success_tests: self.num_success_tests + 1,
-          num_recent_discarded_tests: 0,
-        },
-        prop,
-      )
-    Failed => Ok(self.find_failure(res, ts))
-    Rejected =>
-      next(
-        @state.State::give_up,
-        {
-          ..self,
-          num_discarded_tests: self.num_discarded_tests + 1,
-          num_recent_discarded_tests: self.num_recent_discarded_tests + 1,
-        },
-        prop,
-      )
   }
 }
 

--- a/src/runner.mbt
+++ b/src/runner.mbt
@@ -1,0 +1,78 @@
+///|
+/// Run a single test and return the Ok(result) if ended successfully, or Err(state) if it should continue.
+fn @state.State::run_single_test(
+  self : @state.State,
+  prop : Property,
+) -> Result[@report.TestSuccess, @state.State] raise @report.TestError {
+  let rnd1 = self.random_state.split()
+  let rnd2 = self.random_state
+  let { val: res, branch: ts } = prop.0.run(self.compute_size(), rnd1)
+  fn update_state(st0 : @state.State) {
+    self.random_state = rnd2
+    st0.update_state_from_res(res)
+  }
+
+  fn next(
+    end_with : (@state.State, Property) -> @report.TestSuccess raise @report.TestError,
+    next_state : @state.State,
+    p : Property,
+  ) raise @report.TestError {
+    update_state(next_state)
+    if res.abort {
+      Ok(end_with(next_state, p))
+    } else {
+      Err(next_state)
+    }
+  }
+
+  let stc = self.clone()
+  stc.add_coverages(res) // The failure should not be counted.
+  self.callback_post_test(res)
+  match res.status {
+    Passed =>
+      next(
+        @state.State::complete_test,
+        {
+          ..stc,
+          num_success_tests: self.num_success_tests + 1,
+          num_recent_discarded_tests: 0,
+        },
+        prop,
+      )
+    Failed => Ok(self.find_failure(res, ts))
+    Rejected =>
+      next(
+        @state.State::give_up,
+        {
+          ..self,
+          num_discarded_tests: self.num_discarded_tests + 1,
+          num_recent_discarded_tests: self.num_recent_discarded_tests + 1,
+        },
+        prop,
+      )
+  }
+}
+
+///|
+/// Run the main QuickCheck loop: draw inputs, evaluate the property,
+/// book-keep successes and discards, and on failure hand off to
+/// `find_failure` for shrinking. Returns the aggregated
+/// `TestSuccess` or raises `TestError`.
+fn @state.State::run_test(
+  self : @state.State,
+  prop : Property,
+) -> @report.TestSuccess raise @report.TestError {
+  for cur = self.run_single_test(prop) {
+    match cur {
+      Ok(res) => break res
+      Err(ns) =>
+        if ns.finished_successfully() {
+          break ns.complete_test(prop)
+        } else if ns.discarded_too_much() {
+          break ns.give_up(prop)
+        } else {
+          continue ns.run_single_test(prop)
+        }
+    }
+  }
+}

--- a/src/runner.mbt
+++ b/src/runner.mbt
@@ -6,51 +6,51 @@ fn @state.State::run_test(
   self : @state.State,
   prop : Property,
 ) -> @report.CheckReport {
-  CheckReport(try? {
-  for state = self {
-    let rnd1 = state.random_state.split()
-    let rnd2 = state.random_state
-    let res = prop.0.run(state.compute_size(), rnd1)
-    let stc = state.clone()
-    stc.add_coverages(res.val) // The failure should not be counted.
-    state.callback_post_test(res.val)
-    match res.val.status {
-      Passed => {
-        let ns = {
-          ..stc,
-          num_success_tests: state.num_success_tests + 1,
-          num_recent_discarded_tests: 0,
+  CheckReport(
+    try? (for state = self {
+      let rnd1 = state.random_state.split()
+      let rnd2 = state.random_state
+      let res = prop.0.run(state.compute_size(), rnd1)
+      let stc = state.clone()
+      stc.add_coverages(res.val) // The failure should not be counted.
+      state.callback_post_test(res.val)
+      match res.val.status {
+        Passed => {
+          let ns = {
+            ..stc,
+            num_success_tests: state.num_success_tests + 1,
+            num_recent_discarded_tests: 0,
+          }
+          state.random_state = rnd2
+          ns.update_state_from_res(res.val)
+          if res.val.abort || ns.finished_successfully() {
+            break ns.complete_test(prop)
+          } else if ns.discarded_too_much() {
+            break ns.give_up(prop)
+          } else {
+            continue ns
+          }
         }
-        state.random_state = rnd2
-        ns.update_state_from_res(res.val)
-        if res.val.abort || ns.finished_successfully() {
-          break ns.complete_test(prop)
-        } else if ns.discarded_too_much() {
-          break ns.give_up(prop)
-        } else {
-          continue ns
+        Failed => break state.find_failure(res.val, res.branch)
+        Rejected => {
+          let ns = {
+            ..state,
+            num_discarded_tests: state.num_discarded_tests + 1,
+            num_recent_discarded_tests: state.num_recent_discarded_tests + 1,
+          }
+          state.random_state = rnd2
+          ns.update_state_from_res(res.val)
+          if res.val.abort {
+            break ns.give_up(prop)
+          } else if ns.finished_successfully() {
+            break ns.complete_test(prop)
+          } else if ns.discarded_too_much() {
+            break ns.give_up(prop)
+          } else {
+            continue ns
+          }
         }
       }
-      Failed => break state.find_failure(res.val, res.branch)
-      Rejected => {
-        let ns = {
-          ..state,
-          num_discarded_tests: state.num_discarded_tests + 1,
-          num_recent_discarded_tests: state.num_recent_discarded_tests + 1,
-        }
-        state.random_state = rnd2
-        ns.update_state_from_res(res.val)
-        if res.val.abort {
-          break ns.give_up(prop)
-        } else if ns.finished_successfully() {
-          break ns.complete_test(prop)
-        } else if ns.discarded_too_much() {
-          break ns.give_up(prop)
-        } else {
-          continue ns
-        }
-      }
-    }
-  }
-  })
+    }),
+  )
 }

--- a/src/runner.mbt
+++ b/src/runner.mbt
@@ -1,57 +1,4 @@
 ///|
-/// Run a single test and return the Ok(result) if ended successfully, or Err(state) if it should continue.
-fn @state.State::run_single_test(
-  self : @state.State,
-  prop : Property,
-) -> Result[@report.TestSuccess, @state.State] raise @report.TestError {
-  let rnd1 = self.random_state.split()
-  let rnd2 = self.random_state
-  let { val: res, branch: ts } = prop.0.run(self.compute_size(), rnd1)
-
-  fn next(
-    next_state : @state.State,
-    p : Property,    
-    end_with : (@state.State, Property) -> @report.TestSuccess raise @report.TestError,
-
-  ) raise @report.TestError {
-    self.random_state = rnd2
-    next_state.update_state_from_res(res)
-    if res.abort {
-      Ok(end_with(next_state, p))
-    } else {
-      Err(next_state)
-    }
-  }
-
-  let stc = self.clone()
-  stc.add_coverages(res) // The failure should not be counted.
-  self.callback_post_test(res)
-  match res.status {
-    Passed =>
-      next(
-        {
-          ..stc,
-          num_success_tests: self.num_success_tests + 1,
-          num_recent_discarded_tests: 0,
-        },
-        prop,
-        @state.State::complete_test,
-      )
-    Failed => Ok(self.find_failure(res, ts))
-    Rejected =>
-      next(
-        {
-          ..self,
-          num_discarded_tests: self.num_discarded_tests + 1,
-          num_recent_discarded_tests: self.num_recent_discarded_tests + 1,
-        },        
-        prop,        
-        @state.State::give_up,
-      )
-  }
-}
-
-///|
 /// Run the main QuickCheck loop: draw inputs, evaluate the property,
 /// book-keep successes and discards, and on failure hand off to
 /// `find_failure` for shrinking. Returns the aggregated
@@ -60,17 +7,49 @@ fn @state.State::run_test(
   self : @state.State,
   prop : Property,
 ) -> @report.TestSuccess raise @report.TestError {
-  for cur = self.run_single_test(prop) {
-    match cur {
-      Ok(res) => break res
-      Err(ns) =>
-        if ns.finished_successfully() {
+  for state = self {
+    let rnd1 = state.random_state.split()
+    let rnd2 = state.random_state
+    let res = prop.0.run(state.compute_size(), rnd1)
+    let stc = state.clone()
+    stc.add_coverages(res.val) // The failure should not be counted.
+    state.callback_post_test(res.val)
+    match res.val.status {
+      Passed => {
+        let ns = {
+          ..stc,
+          num_success_tests: state.num_success_tests + 1,
+          num_recent_discarded_tests: 0,
+        }
+        state.random_state = rnd2
+        ns.update_state_from_res(res.val)
+        if res.val.abort || ns.finished_successfully() {
           break ns.complete_test(prop)
         } else if ns.discarded_too_much() {
           break ns.give_up(prop)
         } else {
-          continue ns.run_single_test(prop)
+          continue ns
         }
+      }
+      Failed => break state.find_failure(res.val, res.branch)
+      Rejected => {
+        let ns = {
+          ..state,
+          num_discarded_tests: state.num_discarded_tests + 1,
+          num_recent_discarded_tests: state.num_recent_discarded_tests + 1,
+        }
+        state.random_state = rnd2
+        ns.update_state_from_res(res.val)
+        if res.val.abort {
+          break ns.give_up(prop)
+        } else if ns.finished_successfully() {
+          break ns.complete_test(prop)
+        } else if ns.discarded_too_much() {
+          break ns.give_up(prop)
+        } else {
+          continue ns
+        }
+      }
     }
   }
 }

--- a/src/runner.mbt
+++ b/src/runner.mbt
@@ -7,17 +7,15 @@ fn @state.State::run_single_test(
   let rnd1 = self.random_state.split()
   let rnd2 = self.random_state
   let { val: res, branch: ts } = prop.0.run(self.compute_size(), rnd1)
-  fn update_state(st0 : @state.State) {
-    self.random_state = rnd2
-    st0.update_state_from_res(res)
-  }
 
   fn next(
-    end_with : (@state.State, Property) -> @report.TestSuccess raise @report.TestError,
     next_state : @state.State,
-    p : Property,
+    p : Property,    
+    end_with : (@state.State, Property) -> @report.TestSuccess raise @report.TestError,
+
   ) raise @report.TestError {
-    update_state(next_state)
+    self.random_state = rnd2
+    next_state.update_state_from_res(res)
     if res.abort {
       Ok(end_with(next_state, p))
     } else {
@@ -31,24 +29,24 @@ fn @state.State::run_single_test(
   match res.status {
     Passed =>
       next(
-        @state.State::complete_test,
         {
           ..stc,
           num_success_tests: self.num_success_tests + 1,
           num_recent_discarded_tests: 0,
         },
         prop,
+        @state.State::complete_test,
       )
     Failed => Ok(self.find_failure(res, ts))
     Rejected =>
       next(
-        @state.State::give_up,
         {
           ..self,
           num_discarded_tests: self.num_discarded_tests + 1,
           num_recent_discarded_tests: self.num_recent_discarded_tests + 1,
-        },
-        prop,
+        },        
+        prop,        
+        @state.State::give_up,
       )
   }
 }

--- a/src/runner.mbt
+++ b/src/runner.mbt
@@ -1,12 +1,12 @@
 ///|
 /// Run the main QuickCheck loop: draw inputs, evaluate the property,
 /// book-keep successes and discards, and on failure hand off to
-/// `find_failure` for shrinking. Returns the aggregated
-/// `TestSuccess` or raises `TestError`.
+/// `find_failure` for shrinking. Returns the `CheckReport`.
 fn @state.State::run_test(
   self : @state.State,
   prop : Property,
-) -> @report.TestSuccess raise @report.TestError {
+) -> @report.CheckReport {
+  CheckReport(try? {
   for state = self {
     let rnd1 = state.random_state.split()
     let rnd2 = state.random_state
@@ -52,4 +52,5 @@ fn @state.State::run_test(
       }
     }
   }
+  })
 }

--- a/src/shrink/shrink.mbt
+++ b/src/shrink/shrink.mbt
@@ -40,26 +40,12 @@ pub impl Shrink for Int with shrink(x) {
 }
 
 ///|
-test "shrink int" {
-  json_inspect(Shrink::shrink(100), content=[99, 97, 94, 88, 75, 50, 0])
-  json_inspect(Shrink::shrink(0), content=[])
-}
-
-///|
 pub impl Shrink for Int64 with shrink(x) {
   @utils.apply_while_list(x, z => z / 2, z => (x - z).abs() < x.abs())
   .map(i => x - i)
   .iter()
   .concat(Iter::singleton(0))
   .filter(u => u != x)
-}
-
-///|
-test "shrink int64" {
-  json_inspect(Shrink::shrink(10000L), content=[
-    "9999", "9998", "9996", "9991", "9981", "9961", "9922", "9844", "9688", "9375",
-    "8750", "7500", "5000", "0",
-  ])
 }
 
 ///|
@@ -72,28 +58,12 @@ pub impl Shrink for UInt with shrink(x) {
 }
 
 ///|
-test "shrink uint" {
-  json_inspect(Shrink::shrink(37000U), content=[
-    36999, 36998, 36996, 36991, 36982, 36964, 36928, 36856, 36711, 36422, 35844,
-    34688, 32375, 27750, 18500, 0,
-  ])
-}
-
-///|
 pub impl Shrink for UInt64 with shrink(x) {
   @utils.apply_while_list(x, z => z / 2, z => z > 0)
   .map(i => x - i)
   .iter()
   .concat(Iter::singleton(0))
   .filter(u => u != x)
-}
-
-///|
-test "shrink uint64" {
-  json_inspect(Shrink::shrink((42000 : UInt64)), content=[
-    "41999", "41998", "41995", "41990", "41980", "41959", "41918", "41836", "41672",
-    "41344", "40688", "39375", "36750", "31500", "21000", "0",
-  ])
 }
 
 ///|
@@ -106,12 +76,6 @@ pub impl Shrink for Bool with shrink(b) {
 }
 
 ///|
-test "shrink boolean" {
-  json_inspect(Shrink::shrink(true), content=[false])
-  json_inspect(Shrink::shrink(false), content=[])
-}
-
-///|
 pub impl Shrink for Char with shrink(c) {
   let ci = c.to_int()
   if ci == 0 {
@@ -120,13 +84,6 @@ pub impl Shrink for Char with shrink(c) {
     let (cl, ch) = (Int::unsafe_to_char(ci - 1), Int::unsafe_to_char(ci + 1))
     [cl, ch, 'a', 'A', '1', '\n', '\t', '\b', '\\', '\'', '\r', ' '].iter()
   }
-}
-
-///|
-test "shrink char" {
-  json_inspect(Shrink::shrink('测'), content=[
-    "浊", "浌", "a", "A", "1", "\n", "\t", "\b", "\\", "'", "\r", " ",
-  ])
 }
 
 ///|
@@ -172,60 +129,6 @@ fn shrink_decimal(x : Double) -> Iter[Double] {
 }
 
 ///|
-test "shrink double: pi" {
-  let s = Shrink::shrink(3.14159).to_array()
-  assert_true(s.contains(3.0))
-  assert_true(s.contains(0.0))
-  assert_true(s.all(y => y < 3.14159))
-}
-
-///|
-test "shrink double: exact output for 3.5" {
-  json_inspect(Shrink::shrink(3.5), content=[
-    3, 2, 0, 3.4, 3.3, 3.1, 2.7, 1.8, 0,
-  ])
-}
-
-///|
-test "shrink double: zero" {
-  assert_eq(Shrink::shrink(0.0).to_array(), [])
-}
-
-///|
-test "shrink double: negative" {
-  let s = Shrink::shrink(-5.5).to_array()
-  assert_true(s.contains(5.5))
-  assert_true(s.any(y => y < 0.0))
-}
-
-///|
-test "shrink double: nan" {
-  let s = Shrink::shrink(0.0 / 0.0).to_array()
-  assert_true(s.contains(0.0))
-}
-
-///|
-test "shrink double: infinity" {
-  let s = Shrink::shrink(1.0 / 0.0).to_array()
-  assert_true(s.contains(0.0))
-  assert_true(s.contains(1000.0))
-}
-
-///|
-test "shrink double: small value" {
-  let s = Shrink::shrink(0.001).to_array()
-  assert_true(s.contains(0.0))
-  assert_true(s.all(y => y >= 0.0 && y < 0.001))
-}
-
-///|
-test "shrink float: basic" {
-  let s = Shrink::shrink((3.14 : Float)).to_array()
-  assert_true(s.contains(3.0))
-  assert_true(s.contains(0.0))
-}
-
-///|
 pub impl Shrink for String
 
 ///|
@@ -241,27 +144,7 @@ pub impl[T : Shrink] Shrink for T? with shrink(x) {
 }
 
 ///|
-
-///|
 pub impl Shrink for Unit
-
-///|
-test "shrink option" {
-  json_inspect(Shrink::shrink((None : Unit?)), content=[])
-  json_inspect(Shrink::shrink(Some(1000)), content=[
-    [999],
-    [997],
-    [993],
-    [985],
-    [969],
-    [938],
-    [875],
-    [750],
-    [500],
-    [0],
-    null,
-  ])
-}
 
 ///|
 pub impl[T : Shrink, E : Shrink] Shrink for Result[T, E] with shrink(x) {
@@ -272,42 +155,11 @@ pub impl[T : Shrink, E : Shrink] Shrink for Result[T, E] with shrink(x) {
 }
 
 ///|
-test "shrink result" {
-  let b : Result[Bool, Int] = Err(100)
-  let x : Result[Bool, Int] = Ok(true)
-  json_inspect(Shrink::shrink(b), content=[
-    { "Err": 99 },
-    { "Err": 97 },
-    { "Err": 94 },
-    { "Err": 88 },
-    { "Err": 75 },
-    { "Err": 50 },
-    { "Err": 0 },
-  ])
-  json_inspect(Shrink::shrink(x), content=[{ "Ok": false }])
-}
-
-///|
 pub impl[A : Shrink, B : Shrink] Shrink for (A, B) with shrink(x) {
   let (a, b) = x
   Shrink::shrink(a)
   .map(a1 => (a1, b))
   .concat(Shrink::shrink(b).map(b1 => (a, b1)))
-}
-
-///|
-test "shrink tuple" {
-  let x = (120, true)
-  json_inspect(Shrink::shrink(x), content=[
-    [119, true],
-    [117, true],
-    [113, true],
-    [105, true],
-    [90, true],
-    [60, true],
-    [0, true],
-    [120, false],
-  ])
 }
 
 ///|
@@ -359,6 +211,95 @@ pub impl[A : Shrink, B : Shrink, C : Shrink, D : Shrink, E : Shrink, F : Shrink]
     let (a1, (b1, c1, d1, e1, f1)) = y
     (a1, b1, c1, d1, e1, f1)
   })
+}
+
+///|
+pub impl[T : Shrink] Shrink for @list.List[T] with shrink(xs) {
+  let n = xs.length()
+  fn shr_sub_terms(lst : @list.List[T]) {
+    match lst {
+      Empty => Iter::empty()
+      More(x, tail=xs) =>
+        T::shrink(x)
+        .map(x_ => xs.add(x_))
+        .concat(shr_sub_terms(xs).map(xs_ => xs_.add(x)))
+    }
+  }
+
+  @utils.apply_while_list(n, x => x / 2, x => x > 0)
+  .map(k => @utils.removes_list(k, n, xs))
+  .flatten()
+  .iter()
+  .concat(shr_sub_terms(xs))
+}
+
+///|
+/// Shrink non-empty list without producing the empty list.
+///
+/// ```mbt check
+/// test {
+///   let xs : @list.List[Int] = @list.from_array([5])
+///   // Default list shrink would produce [], which is filtered out here.
+///   assert_true(shrink_non_empty_list(xs).all(ys => !ys.is_empty()))
+/// }
+/// ```
+pub fn[T : Shrink] shrink_non_empty_list(
+  xs : @list.List[T],
+) -> Iter[@list.List[T]] {
+  Shrink::shrink(xs).filter(ys => !ys.is_empty())
+}
+
+///|
+pub impl[X : Shrink] Shrink for Array[X] with shrink(xs) {
+  let view = xs[:]
+  let n = view.length()
+  fn shr_sub_terms(arr : ArrayView[X]) {
+    match arr {
+      [] => Iter::empty()
+      [x, .. xs] =>
+        X::shrink(x)
+        .map(x_ => [x_, ..xs])
+        .concat(shr_sub_terms(xs).map(xs_ => [x, ..xs_]))
+    }
+  }
+
+  @utils.apply_while_array(n, x => x / 2, x => x > 0)
+  .map(k => @utils.removes_array(k, n, xs))
+  .flatten()
+  .iter()
+  .concat(shr_sub_terms(view))
+}
+
+///|
+/// Shrink non-empty array without producing the empty array.
+///
+/// ```mbt check
+/// test {
+///   assert_true(shrink_non_empty_array([1, 2, 3]).all(ys => ys.length() > 0))
+/// }
+/// ```
+pub fn[X : Shrink] shrink_non_empty_array(xs : Array[X]) -> Iter[Array[X]] {
+  Shrink::shrink(xs).filter(ys => ys.length() > 0)
+}
+
+///|
+pub impl[X : Shrink] Shrink for Iter[X] with shrink(xs) {
+  let arr = xs.to_array()
+  let its : Array[_] = Array::makei(arr.length(), x => {
+    X::shrink(arr[x])
+    .map(y => {
+      let cp = arr.copy()
+      cp[x] = y
+      cp.iter()
+    })
+    .to_array()
+  }).flatten()
+  let rms : Array[Iter[X]] = arr.mapi((i, _) => {
+    let a = arr.copy()
+    a.remove(i) |> ignore
+    a.iter()
+  })
+  rms.iter().concat(its.iter())
 }
 
 ///|
@@ -465,282 +406,4 @@ pub fn[T : Shrink + Compare] shrink_sorted_distinct_array(
     })
   }
   shrink_remove_one_array(xs).concat(shrink_one_val(xs))
-}
-
-///|
-test "shrink 6-tuple" {
-  let x = (20, 'A', 30U, true, true, true)
-  json_inspect(Shrink::shrink(x), content=[
-    [19, "A", 30, true, true, true],
-    [18, "A", 30, true, true, true],
-    [15, "A", 30, true, true, true],
-    [10, "A", 30, true, true, true],
-    [0, "A", 30, true, true, true],
-    [20, "@", 30, true, true, true],
-    [20, "B", 30, true, true, true],
-    [20, "a", 30, true, true, true],
-    [20, "A", 30, true, true, true],
-    [20, "1", 30, true, true, true],
-    [20, "\n", 30, true, true, true],
-    [20, "\t", 30, true, true, true],
-    [20, "\b", 30, true, true, true],
-    [20, "\\", 30, true, true, true],
-    [20, "'", 30, true, true, true],
-    [20, "\r", 30, true, true, true],
-    [20, " ", 30, true, true, true],
-    [20, "A", 29, true, true, true],
-    [20, "A", 27, true, true, true],
-    [20, "A", 23, true, true, true],
-    [20, "A", 15, true, true, true],
-    [20, "A", 0, true, true, true],
-    [20, "A", 30, false, true, true],
-    [20, "A", 30, true, false, true],
-    [20, "A", 30, true, true, false],
-  ])
-}
-
-///|
-pub impl[T : Shrink] Shrink for @list.List[T] with shrink(xs) {
-  let n = xs.length()
-  fn shr_sub_terms(lst : @list.List[T]) {
-    match lst {
-      Empty => Iter::empty()
-      More(x, tail=xs) =>
-        T::shrink(x)
-        .map(x_ => xs.add(x_))
-        .concat(shr_sub_terms(xs).map(xs_ => xs_.add(x)))
-    }
-  }
-
-  @utils.apply_while_list(n, x => x / 2, x => x > 0)
-  .map(k => @utils.removes_list(k, n, xs))
-  .flatten()
-  .iter()
-  .concat(shr_sub_terms(xs))
-}
-
-///|
-/// Shrink non-empty list without producing the empty list.
-///
-/// ```mbt check
-/// test {
-///   let xs : @list.List[Int] = @list.from_array([5])
-///   // Default list shrink would produce [], which is filtered out here.
-///   assert_true(shrink_non_empty_list(xs).all(ys => !ys.is_empty()))
-/// }
-/// ```
-pub fn[T : Shrink] shrink_non_empty_list(
-  xs : @list.List[T],
-) -> Iter[@list.List[T]] {
-  Shrink::shrink(xs).filter(ys => !ys.is_empty())
-}
-
-///|
-test "shrink int list" {
-  let il : @list.List[Int] = @list.from_array([1, 2, 3, 4, 5, 6])
-  let s = Shrink::shrink(il)
-  json_inspect(s, content=[
-    [2, 3, 4, 5, 6],
-    [1, 3, 4, 5, 6],
-    [1, 2, 4, 5, 6],
-    [1, 2, 3, 5, 6],
-    [1, 2, 3, 4, 6],
-    [4, 5, 6],
-    [0, 2, 3, 4, 5, 6],
-    [1, 1, 3, 4, 5, 6],
-    [1, 0, 3, 4, 5, 6],
-    [1, 2, 2, 4, 5, 6],
-    [1, 2, 0, 4, 5, 6],
-    [1, 2, 3, 3, 5, 6],
-    [1, 2, 3, 2, 5, 6],
-    [1, 2, 3, 0, 5, 6],
-    [1, 2, 3, 4, 4, 6],
-    [1, 2, 3, 4, 3, 6],
-    [1, 2, 3, 4, 0, 6],
-    [1, 2, 3, 4, 5, 5],
-    [1, 2, 3, 4, 5, 3],
-    [1, 2, 3, 4, 5, 0],
-  ])
-}
-
-///|
-test "shrink non-empty list" {
-  let il : @list.List[Int] = @list.from_array([1])
-  json_inspect(shrink_non_empty_list(il), content=[[0]])
-}
-
-///|
-pub impl[X : Shrink] Shrink for Array[X] with shrink(xs) {
-  let view = xs[:]
-  let n = view.length()
-  fn shr_sub_terms(arr : ArrayView[X]) {
-    match arr {
-      [] => Iter::empty()
-      [x, .. xs] =>
-        X::shrink(x)
-        .map(x_ => [x_, ..xs])
-        .concat(shr_sub_terms(xs).map(xs_ => [x, ..xs_]))
-    }
-  }
-
-  @utils.apply_while_array(n, x => x / 2, x => x > 0)
-  .map(k => @utils.removes_array(k, n, xs))
-  .flatten()
-  .iter()
-  .concat(shr_sub_terms(view))
-}
-
-///|
-/// Shrink non-empty array without producing the empty array.
-///
-/// ```mbt check
-/// test {
-///   assert_true(shrink_non_empty_array([1, 2, 3]).all(ys => ys.length() > 0))
-/// }
-/// ```
-pub fn[X : Shrink] shrink_non_empty_array(xs : Array[X]) -> Iter[Array[X]] {
-  Shrink::shrink(xs).filter(ys => ys.length() > 0)
-}
-
-///|
-test "shrink array" {
-  let ar = [1, 2, 3, 4, 5, 6]
-  let s = Shrink::shrink(ar)
-  json_inspect(s, content=[
-    [2, 3, 4, 5, 6],
-    [1, 3, 4, 5, 6],
-    [1, 2, 4, 5, 6],
-    [1, 2, 3, 5, 6],
-    [1, 2, 3, 4, 6],
-    [4, 5, 6],
-    [0, 2, 3, 4, 5, 6],
-    [1, 1, 3, 4, 5, 6],
-    [1, 0, 3, 4, 5, 6],
-    [1, 2, 2, 4, 5, 6],
-    [1, 2, 0, 4, 5, 6],
-    [1, 2, 3, 3, 5, 6],
-    [1, 2, 3, 2, 5, 6],
-    [1, 2, 3, 0, 5, 6],
-    [1, 2, 3, 4, 4, 6],
-    [1, 2, 3, 4, 3, 6],
-    [1, 2, 3, 4, 0, 6],
-    [1, 2, 3, 4, 5, 5],
-    [1, 2, 3, 4, 5, 3],
-    [1, 2, 3, 4, 5, 0],
-  ])
-}
-
-///|
-test "shrink non-empty array" {
-  json_inspect(shrink_non_empty_array([1]), content=[[0]])
-}
-
-///|
-pub impl[X : Shrink] Shrink for Iter[X] with shrink(xs) {
-  let arr = xs.to_array()
-  let its : Array[_] = Array::makei(arr.length(), x => {
-    X::shrink(arr[x])
-    .map(y => {
-      let cp = arr.copy()
-      cp[x] = y
-      cp.iter()
-    })
-    .to_array()
-  }).flatten()
-  let rms : Array[Iter[X]] = arr.mapi((i, _) => {
-    let a = arr.copy()
-    a.remove(i) |> ignore
-    a.iter()
-  })
-  rms.iter().concat(its.iter())
-}
-
-///|
-test "shrink iter" {
-  let it = [1, 2, 3, 4, 5, 6].iter()
-  json_inspect(Shrink::shrink(it), content=[
-    [2, 3, 4, 5, 6],
-    [1, 3, 4, 5, 6],
-    [1, 2, 4, 5, 6],
-    [1, 2, 3, 5, 6],
-    [1, 2, 3, 4, 6],
-    [1, 2, 3, 4, 5],
-    [0, 2, 3, 4, 5, 6],
-    [1, 1, 3, 4, 5, 6],
-    [1, 0, 3, 4, 5, 6],
-    [1, 2, 2, 4, 5, 6],
-    [1, 2, 0, 4, 5, 6],
-    [1, 2, 3, 3, 5, 6],
-    [1, 2, 3, 2, 5, 6],
-    [1, 2, 3, 0, 5, 6],
-    [1, 2, 3, 4, 4, 6],
-    [1, 2, 3, 4, 3, 6],
-    [1, 2, 3, 4, 0, 6],
-    [1, 2, 3, 4, 5, 5],
-    [1, 2, 3, 4, 5, 3],
-    [1, 2, 3, 4, 5, 0],
-  ])
-}
-
-///|
-test "shrink sorted array" {
-  let ar = [1, 3, 5, 7, 9]
-  let s = shrink_sorted_array(ar, lo=0, hi=10)
-  let content = s.to_array()
-  json_inspect(content, content=[
-    [3, 5, 7, 9],
-    [1, 5, 7, 9],
-    [1, 3, 7, 9],
-    [1, 3, 5, 9],
-    [1, 3, 5, 7],
-    [0, 3, 5, 7, 9],
-    [1, 2, 5, 7, 9],
-    [1, 3, 4, 7, 9],
-    [1, 3, 3, 7, 9],
-    [1, 3, 5, 6, 9],
-    [1, 3, 5, 7, 8],
-    [1, 3, 5, 7, 7],
-  ])
-}
-
-///|
-test "shrink distinct array" {
-  let s = shrink_distinct_array([1, 3, 5])
-  json_inspect(s, content=[
-    [3, 5],
-    [1, 5],
-    [1, 3],
-    [0, 3, 5],
-    [1, 2, 5],
-    [1, 0, 5],
-    [1, 3, 4],
-    [1, 3, 0],
-  ])
-}
-
-///|
-test "shrink sorted distinct array" {
-  let s = shrink_sorted_distinct_array([1, 3, 5], lo=0, hi=9)
-  json_inspect(s, content=[
-    [3, 5],
-    [1, 5],
-    [1, 3],
-    [0, 3, 5],
-    [1, 2, 5],
-    [1, 3, 4],
-  ])
-}
-
-///|
-test "shrink sorted list" {
-  let xs : @list.List[Int] = @list.from_array([1, 3, 5])
-  json_inspect(shrink_sorted_list(xs, lo=0, hi=9), content=[
-    [3, 5],
-    [1, 5],
-    [1, 3],
-    [0, 3, 5],
-    [1, 2, 5],
-    [1, 3, 4],
-    [1, 3, 3],
-  ])
 }

--- a/src/shrink/shrink_test.mbt
+++ b/src/shrink/shrink_test.mbt
@@ -1,0 +1,334 @@
+///|
+test "shrink int" {
+  json_inspect(@shrink.Shrink::shrink(100), content=[99, 97, 94, 88, 75, 50, 0])
+  json_inspect(@shrink.Shrink::shrink(0), content=[])
+}
+
+///|
+test "shrink int64" {
+  json_inspect(@shrink.Shrink::shrink(10000L), content=[
+    "9999", "9998", "9996", "9991", "9981", "9961", "9922", "9844", "9688", "9375",
+    "8750", "7500", "5000", "0",
+  ])
+}
+
+///|
+test "shrink uint" {
+  json_inspect(@shrink.Shrink::shrink(37000U), content=[
+    36999, 36998, 36996, 36991, 36982, 36964, 36928, 36856, 36711, 36422, 35844,
+    34688, 32375, 27750, 18500, 0,
+  ])
+}
+
+///|
+test "shrink uint64" {
+  json_inspect(@shrink.Shrink::shrink((42000 : UInt64)), content=[
+    "41999", "41998", "41995", "41990", "41980", "41959", "41918", "41836", "41672",
+    "41344", "40688", "39375", "36750", "31500", "21000", "0",
+  ])
+}
+
+///|
+test "shrink boolean" {
+  json_inspect(@shrink.Shrink::shrink(true), content=[false])
+  json_inspect(@shrink.Shrink::shrink(false), content=[])
+}
+
+///|
+test "shrink char" {
+  json_inspect(@shrink.Shrink::shrink('测'), content=[
+    "浊", "浌", "a", "A", "1", "\n", "\t", "\b", "\\", "'", "\r", " ",
+  ])
+}
+
+///|
+test "shrink double: pi" {
+  let s = @shrink.Shrink::shrink(3.14159).to_array()
+  assert_true(s.contains(3.0))
+  assert_true(s.contains(0.0))
+  assert_true(s.all(y => y < 3.14159))
+}
+
+///|
+test "shrink double: exact output for 3.5" {
+  json_inspect(@shrink.Shrink::shrink(3.5), content=[
+    3, 2, 0, 3.4, 3.3, 3.1, 2.7, 1.8, 0,
+  ])
+}
+
+///|
+test "shrink double: zero" {
+  assert_eq(@shrink.Shrink::shrink(0.0).to_array(), [])
+}
+
+///|
+test "shrink double: negative" {
+  let s = @shrink.Shrink::shrink(-5.5).to_array()
+  assert_true(s.contains(5.5))
+  assert_true(s.any(y => y < 0.0))
+}
+
+///|
+test "shrink double: nan" {
+  let s = @shrink.Shrink::shrink(0.0 / 0.0).to_array()
+  assert_true(s.contains(0.0))
+}
+
+///|
+test "shrink double: infinity" {
+  let s = @shrink.Shrink::shrink(1.0 / 0.0).to_array()
+  assert_true(s.contains(0.0))
+  assert_true(s.contains(1000.0))
+}
+
+///|
+test "shrink double: small value" {
+  let s = @shrink.Shrink::shrink(0.001).to_array()
+  assert_true(s.contains(0.0))
+  assert_true(s.all(y => y >= 0.0 && y < 0.001))
+}
+
+///|
+test "shrink float: basic" {
+  let s = @shrink.Shrink::shrink((3.14 : Float)).to_array()
+  assert_true(s.contains(3.0))
+  assert_true(s.contains(0.0))
+}
+
+///|
+test "shrink option" {
+  json_inspect(@shrink.Shrink::shrink((None : Unit?)), content=[])
+  json_inspect(@shrink.Shrink::shrink(Some(1000)), content=[
+    [999],
+    [997],
+    [993],
+    [985],
+    [969],
+    [938],
+    [875],
+    [750],
+    [500],
+    [0],
+    null,
+  ])
+}
+
+///|
+test "shrink result" {
+  let b : Result[Bool, Int] = Err(100)
+  let x : Result[Bool, Int] = Ok(true)
+  json_inspect(@shrink.Shrink::shrink(b), content=[
+    { "Err": 99 },
+    { "Err": 97 },
+    { "Err": 94 },
+    { "Err": 88 },
+    { "Err": 75 },
+    { "Err": 50 },
+    { "Err": 0 },
+  ])
+  json_inspect(@shrink.Shrink::shrink(x), content=[{ "Ok": false }])
+}
+
+///|
+test "shrink tuple" {
+  let x = (120, true)
+  json_inspect(@shrink.Shrink::shrink(x), content=[
+    [119, true],
+    [117, true],
+    [113, true],
+    [105, true],
+    [90, true],
+    [60, true],
+    [0, true],
+    [120, false],
+  ])
+}
+
+///|
+test "shrink 6-tuple" {
+  let x = (20, 'A', 30U, true, true, true)
+  json_inspect(@shrink.Shrink::shrink(x), content=[
+    [19, "A", 30, true, true, true],
+    [18, "A", 30, true, true, true],
+    [15, "A", 30, true, true, true],
+    [10, "A", 30, true, true, true],
+    [0, "A", 30, true, true, true],
+    [20, "@", 30, true, true, true],
+    [20, "B", 30, true, true, true],
+    [20, "a", 30, true, true, true],
+    [20, "A", 30, true, true, true],
+    [20, "1", 30, true, true, true],
+    [20, "\n", 30, true, true, true],
+    [20, "\t", 30, true, true, true],
+    [20, "\b", 30, true, true, true],
+    [20, "\\", 30, true, true, true],
+    [20, "'", 30, true, true, true],
+    [20, "\r", 30, true, true, true],
+    [20, " ", 30, true, true, true],
+    [20, "A", 29, true, true, true],
+    [20, "A", 27, true, true, true],
+    [20, "A", 23, true, true, true],
+    [20, "A", 15, true, true, true],
+    [20, "A", 0, true, true, true],
+    [20, "A", 30, false, true, true],
+    [20, "A", 30, true, false, true],
+    [20, "A", 30, true, true, false],
+  ])
+}
+
+///|
+test "shrink int list" {
+  let il : @list.List[Int] = @list.from_array([1, 2, 3, 4, 5, 6])
+  let s = @shrink.Shrink::shrink(il)
+  json_inspect(s, content=[
+    [2, 3, 4, 5, 6],
+    [1, 3, 4, 5, 6],
+    [1, 2, 4, 5, 6],
+    [1, 2, 3, 5, 6],
+    [1, 2, 3, 4, 6],
+    [4, 5, 6],
+    [0, 2, 3, 4, 5, 6],
+    [1, 1, 3, 4, 5, 6],
+    [1, 0, 3, 4, 5, 6],
+    [1, 2, 2, 4, 5, 6],
+    [1, 2, 0, 4, 5, 6],
+    [1, 2, 3, 3, 5, 6],
+    [1, 2, 3, 2, 5, 6],
+    [1, 2, 3, 0, 5, 6],
+    [1, 2, 3, 4, 4, 6],
+    [1, 2, 3, 4, 3, 6],
+    [1, 2, 3, 4, 0, 6],
+    [1, 2, 3, 4, 5, 5],
+    [1, 2, 3, 4, 5, 3],
+    [1, 2, 3, 4, 5, 0],
+  ])
+}
+
+///|
+test "shrink non-empty list" {
+  let il : @list.List[Int] = @list.from_array([1])
+  json_inspect(@shrink.shrink_non_empty_list(il), content=[[0]])
+}
+
+///|
+test "shrink array" {
+  let ar = [1, 2, 3, 4, 5, 6]
+  let s = @shrink.Shrink::shrink(ar)
+  json_inspect(s, content=[
+    [2, 3, 4, 5, 6],
+    [1, 3, 4, 5, 6],
+    [1, 2, 4, 5, 6],
+    [1, 2, 3, 5, 6],
+    [1, 2, 3, 4, 6],
+    [4, 5, 6],
+    [0, 2, 3, 4, 5, 6],
+    [1, 1, 3, 4, 5, 6],
+    [1, 0, 3, 4, 5, 6],
+    [1, 2, 2, 4, 5, 6],
+    [1, 2, 0, 4, 5, 6],
+    [1, 2, 3, 3, 5, 6],
+    [1, 2, 3, 2, 5, 6],
+    [1, 2, 3, 0, 5, 6],
+    [1, 2, 3, 4, 4, 6],
+    [1, 2, 3, 4, 3, 6],
+    [1, 2, 3, 4, 0, 6],
+    [1, 2, 3, 4, 5, 5],
+    [1, 2, 3, 4, 5, 3],
+    [1, 2, 3, 4, 5, 0],
+  ])
+}
+
+///|
+test "shrink non-empty array" {
+  json_inspect(@shrink.shrink_non_empty_array([1]), content=[[0]])
+}
+
+///|
+test "shrink iter" {
+  let it = [1, 2, 3, 4, 5, 6].iter()
+  json_inspect(@shrink.Shrink::shrink(it), content=[
+    [2, 3, 4, 5, 6],
+    [1, 3, 4, 5, 6],
+    [1, 2, 4, 5, 6],
+    [1, 2, 3, 5, 6],
+    [1, 2, 3, 4, 6],
+    [1, 2, 3, 4, 5],
+    [0, 2, 3, 4, 5, 6],
+    [1, 1, 3, 4, 5, 6],
+    [1, 0, 3, 4, 5, 6],
+    [1, 2, 2, 4, 5, 6],
+    [1, 2, 0, 4, 5, 6],
+    [1, 2, 3, 3, 5, 6],
+    [1, 2, 3, 2, 5, 6],
+    [1, 2, 3, 0, 5, 6],
+    [1, 2, 3, 4, 4, 6],
+    [1, 2, 3, 4, 3, 6],
+    [1, 2, 3, 4, 0, 6],
+    [1, 2, 3, 4, 5, 5],
+    [1, 2, 3, 4, 5, 3],
+    [1, 2, 3, 4, 5, 0],
+  ])
+}
+
+///|
+test "shrink sorted array" {
+  let ar = [1, 3, 5, 7, 9]
+  let s = @shrink.shrink_sorted_array(ar, lo=0, hi=10)
+  let content = s.to_array()
+  json_inspect(content, content=[
+    [3, 5, 7, 9],
+    [1, 5, 7, 9],
+    [1, 3, 7, 9],
+    [1, 3, 5, 9],
+    [1, 3, 5, 7],
+    [0, 3, 5, 7, 9],
+    [1, 2, 5, 7, 9],
+    [1, 3, 4, 7, 9],
+    [1, 3, 3, 7, 9],
+    [1, 3, 5, 6, 9],
+    [1, 3, 5, 7, 8],
+    [1, 3, 5, 7, 7],
+  ])
+}
+
+///|
+test "shrink distinct array" {
+  let s = @shrink.shrink_distinct_array([1, 3, 5])
+  json_inspect(s, content=[
+    [3, 5],
+    [1, 5],
+    [1, 3],
+    [0, 3, 5],
+    [1, 2, 5],
+    [1, 0, 5],
+    [1, 3, 4],
+    [1, 3, 0],
+  ])
+}
+
+///|
+test "shrink sorted distinct array" {
+  let s = @shrink.shrink_sorted_distinct_array([1, 3, 5], lo=0, hi=9)
+  json_inspect(s, content=[
+    [3, 5],
+    [1, 5],
+    [1, 3],
+    [0, 3, 5],
+    [1, 2, 5],
+    [1, 3, 4],
+  ])
+}
+
+///|
+test "shrink sorted list" {
+  let xs : @list.List[Int] = @list.from_array([1, 3, 5])
+  json_inspect(@shrink.shrink_sorted_list(xs, lo=0, hi=9), content=[
+    [3, 5],
+    [1, 5],
+    [1, 3],
+    [0, 3, 5],
+    [1, 2, 5],
+    [1, 3, 4],
+    [1, 3, 3],
+  ])
+}


### PR DESCRIPTION
## Summary

Refactoring changes to simplify the test runner and improve test organization.

### Changes

1. **Move shrink tests to blackbox tests** — Extracted all inline tests from `src/shrink/shrink.mbt` into a dedicated `src/shrink/shrink_test.mbt` blackbox test file.

2. **Inline `run_single_test` into `run_test`** — Eliminated the intermediate `Result` wrapping and closure allocation by merging the single-test logic directly into the main loop, using `break`/`continue` for control flow.

3. **Return `CheckReport` directly from `run_test`** — `run_test` now wraps its own `try?` internally and returns `CheckReport`, removing the need for `quick_check_with_result`.

All 331 tests pass with no regressions.