### PR TITLE
refactor: drop redundant .iter() where array flows into Iter[_]

### DIFF
--- a/src/internal/rose/README.mbt.md
+++ b/src/internal/rose/README.mbt.md
@@ -145,7 +145,7 @@ test "pure is a leaf with no alternatives" {
 
 ///|
 test "new attaches explicit shrinks" {
-  let rose = @rose.Rose(3, [@rose.pure(0), @rose.pure(1), @rose.pure(2)].iter())
+  let rose = @rose.Rose(3, [@rose.pure(0), @rose.pure(1), @rose.pure(2)])
   assert_eq(rose.val, 3)
   let children = rose.branch.collect()
   assert_eq(children.length(), 3)
@@ -221,7 +221,7 @@ Pathological example — *don't construct trees like this*:
 // Children are LARGER than the parent. The driver, asked "is there
 // something smaller that still fails?", happily descends into 100,
 // then 100's "shrinks" (which would be even larger), and never stops.
-@rose.Rose(1, [@rose.pure(100), @rose.pure(200)].iter())
+@rose.Rose(1, [@rose.pure(100), @rose.pure(200)])
 ```
 
 The invariants aren't checked by the type system. You uphold them
@@ -266,7 +266,7 @@ Maps `f` over every node in the tree. Structure is preserved.
 ```mbt check
 ///|
 test "fmap relabels every node" {
-  let r = @rose.Rose(2, [@rose.pure(0), @rose.pure(1)].iter())
+  let r = @rose.Rose(2, [@rose.pure(0), @rose.pure(1)])
   let doubled = r.fmap(x => x * 10)
   assert_eq(doubled.val, 20)
   let children : Array[Int] = doubled.branch.map(c => c.val).collect()
@@ -284,7 +284,7 @@ after the new sub-trees.
 ```mbt check
 ///|
 test "bind substitutes at every node" {
-  let r = @rose.Rose(1, [@rose.pure(0)].iter())
+  let r = @rose.Rose(1, [@rose.pure(0)])
   // For every node n, emit a Rose that also has "n - 1" as an alternative.
   let expanded = r.bind(n => {
     Rose(
@@ -307,11 +307,8 @@ test "bind substitutes at every node" {
 ///|
 test "join flattens Rose[Rose[T]] into Rose[T]" {
   // Outer tree of Roses; the root already carries a Rose[Int].
-  let inner = @rose.Rose(10, [@rose.pure(5)].iter())
-  let outer : @rose.Rose[@rose.Rose[Int]] = Rose(
-    inner,
-    [@rose.pure(@rose.pure(7))].iter(),
-  )
+  let inner = @rose.Rose(10, [@rose.pure(5)])
+  let outer : @rose.Rose[@rose.Rose[Int]] = Rose(inner, [@rose.pure(@rose.pure(7))])
   let flat = outer.join()
   // The root value is the root of the inner Rose.
   assert_eq(flat.val, 10)
@@ -331,7 +328,7 @@ decorate a generated tree.
 ```mbt check
 ///|
 test "apply rewrites a single node" {
-  let r = @rose.Rose(10, [@rose.pure(5), @rose.pure(0)].iter())
+  let r = @rose.Rose(10, [@rose.pure(5), @rose.pure(0)])
   // Collapse the tree: drop all branches, keep only the root.
   let collapsed = r.apply((v, _) => @rose.pure(v))
   assert_eq(collapsed.val, 10)
@@ -350,17 +347,14 @@ loop calls `<expr>.iter()`, you can use `Rose` directly with the loop sugar.
 test "iter visits root then branches in DFS order" {
   let tree = @rose.Rose(
     1,
-    [
-      @rose.Rose(2, [@rose.pure(3), @rose.pure(4)].iter()),
-      Rose(5, [@rose.pure(6)].iter()),
-    ].iter(),
+    [Rose(2, [@rose.pure(3), @rose.pure(4)]), Rose(5, [@rose.pure(6)])],
   )
   @debug.assert_eq(tree.iter().collect(), [1, 2, 3, 4, 5, 6])
 }
 
 ///|
 test "for .. in walks every value" {
-  let tree = @rose.Rose(10, [@rose.pure(20), @rose.pure(30)].iter())
+  let tree = @rose.Rose(10, [@rose.pure(20), @rose.pure(30)])
 
   @debug.assert_eq([ for x in tree => x ], [10, 20, 30])
 }

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -70,7 +70,7 @@ pub fn[T] pure(val : T) -> Rose[T] {
 ///
 /// ```mbt check
 /// test {
-///   let tree = @rose.Rose(1, [pure(2), pure(3)].iter())
+///   let tree = @rose.Rose(1, [pure(2), pure(3)])
 ///   let doubled = tree.fmap(x => x * 2)
 ///   @debug.assert_eq(doubled.iter().collect(), [2, 4, 6])
 /// }
@@ -91,7 +91,7 @@ test "iter walks root then branches in depth-first order" {
   let leaf = pure
   let tree = Rose(
     1,
-    [Rose(2, [leaf(3), leaf(4)].iter()), Rose(5, [leaf(6)].iter())].iter(),
+    [Rose(2, [leaf(3), leaf(4)]), Rose(5, [leaf(6)])],
   )
 
   @debug.assert_eq([..tree], [1, 2, 3, 4, 5, 6])
@@ -104,7 +104,7 @@ test "iter on a leaf yields only the root" {
 
 ///|
 test "for .. in sugar walks every value" {
-  let tree = Rose(10, [pure(20), pure(30)].iter())
+  let tree = Rose(10, [pure(20), pure(30)])
 
   @debug.assert_eq([ for x in tree => x ], [10, 20, 30])
 }

--- a/src/internal/rose/rose_test.mbt
+++ b/src/internal/rose/rose_test.mbt
@@ -74,10 +74,7 @@ test "find_min_failing skips passing siblings and follows the first failing bran
   //
   // Walk: 10 fails → first child 3 passes (skip) → second child 8 fails →
   // descend into 8 → only child 5 passes → 8 is the smallest failure.
-  let r = @rose.Rose(
-    10,
-    [@rose.pure(3), Rose(8, [@rose.pure(5)].iter())].iter(),
-  )
+  let r = @rose.Rose(10, [@rose.pure(3), Rose(8, [@rose.pure(5)])])
   debug_inspect(find_min_failing(r, x => x >= 6), content="Some(8)")
 }
 

--- a/src/shrink/shrink.mbt
+++ b/src/shrink/shrink.mbt
@@ -92,7 +92,7 @@ pub impl Shrink for Char with shrink(c) {
     return Iter::empty()
   } else {
     let (cl, ch) = (Int::unsafe_to_char(ci - 1), Int::unsafe_to_char(ci + 1))
-    [cl, ch, 'a', 'A', '1', '\n', '\t', '\b', '\\', '\'', '\r', ' '].iter()
+    [cl, ch, 'a', 'A', '1', '\n', '\t', '\b', '\\', '\'', '\r', ' ']
   }
 }
 
@@ -118,8 +118,8 @@ pub impl Shrink for Float with shrink(x) {
 ///   strictly closer to zero is emitted, along with integer-shrink
 ///   candidates of the scaled mantissa.
 fn shrink_decimal(x : Double) -> Iter[Double] {
-  guard !x.is_nan() else { [0.0, 1.0, -1.0, 2.0].iter() }
-  guard !x.is_inf() else { [0.0, 1.0, -1.0, 1000.0, -1000.0].iter() }
+  guard !x.is_nan() else { [0.0, 1.0, -1.0, 2.0] }
+  guard !x.is_inf() else { [0.0, 1.0, -1.0, 1000.0, -1000.0] }
   guard x >= 0.0 else {
     Iter::singleton(-x).concat(shrink_decimal(-x).map(Double::neg))
   }


### PR DESCRIPTION
## Summary
The compiler now coerces an array literal to `Iter[_]` when the surrounding type expects an `Iter`, so the explicit `.iter()` on a literal argument is redundant. This PR removes 14 such call-sites across the `rose` and `shrink` packages.

Sites touched:
- `src/internal/rose/rose.mbt` — `Rose(_, [...])` constructions in tests and a doctest.
- `src/internal/rose/rose_test.mbt` — same shape inside `find_min_failing` test.
- `src/internal/rose/README.mbt.md` — eight doctest examples.
- `src/shrink/shrink.mbt` — `Shrink for Char` and `shrink_decimal` return positions.

Skipped intentionally:
- `let it = [1,2,3,4,5,6].iter()` in `shrink_test.mbt` — no contextual type, so removing `.iter()` would require an explicit annotation that's no shorter.
- `[1.0, 10.0, ...].iter().flat_map(...)` chains in `shrink_decimal` — `.iter()` is needed to reach `Iter` methods like `flat_map`.

## Test plan
- [x] `moon check --target all` — 0 warnings
- [x] `moon test --target native` — 356/356 pass
- [x] `moon test --target wasm-gc` — 356/356 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)