### PR TITLE
Fix compiler warnings

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -12,6 +12,4 @@ keywords = [ "property-based-testing", "quickcheck" ]
 
 description = "Automatic testing of MoonBit programs"
 
-options(
-  source: "src",
-)
+source = "src"

--- a/src/feat/enumerable.mbt
+++ b/src/feat/enumerable.mbt
@@ -65,7 +65,7 @@ pub impl Enumerable for Char with fn enumerate() {
 ///|
 pub impl[E : Enumerable] Enumerable for @moonbitlang/core/list.List[E] with fn enumerate() {
   consts(
-    @list.from_array([
+    List([
       singleton(@list.empty()),
       unary((pair : (E, @moonbitlang/core/list.List[E])) => pair.1.add(pair.0)),
     ]),

--- a/src/feat/enumerate.mbt
+++ b/src/feat/enumerate.mbt
@@ -23,7 +23,7 @@ fn[T] delay(thunk : () -> T) -> () -> T {
 
 ///|
 fn[T] make(run : (Int) -> @ifseq.Seq[T]) -> Enumerate[T] {
-  let cache : Map[Int, @ifseq.Seq[T]] = {}
+  let cache : Map[Int, @ifseq.Seq[T]] = Map([])
   fn memoized(size : Int) -> @ifseq.Seq[T] {
     match cache.get(size) {
       Some(seq) => seq
@@ -170,7 +170,7 @@ pub fn[T] finite(xs : @list.List[T]) -> Enumerate[T] {
 ///|
 /// Explicit memoized fixpoint helper for recursive enumerations.
 pub fn[T] fix(f : (Enumerate[T]) -> Enumerate[T]) -> Enumerate[T] {
-  let cache : Map[Int, @ifseq.Seq[T]] = {}
+  let cache : Map[Int, @ifseq.Seq[T]] = Map([])
   let body_cache : Array[Enumerate[T]] = []
   fn run(size : Int) -> @ifseq.Seq[T] {
     match cache.get(size) {

--- a/src/feat/small_check.mbt
+++ b/src/feat/small_check.mbt
@@ -42,9 +42,12 @@ pub fn[A : Enumerable + Debug, B : Testable] small_check(
   abort? : Bool = false,
   verbose? : Bool = false,
 ) -> Unit raise Failure {
-  let report = @report.CheckReport(
-    try? small_check_with_result(f, max_size, expect, abort),
-  )
+  let result = try
+    small_check_with_result(f, max_size, expect, abort) |> Ok
+  catch {
+    error => Err(error)
+  }
+  let report = @report.CheckReport(result)
   finish_report(report, verbose)
 }
 
@@ -58,9 +61,12 @@ pub fn[A : Enumerable + Debug, B : Testable] small_check_silence(
   abort? : Bool = false,
   verbose? : Bool = false,
 ) -> String {
-  @report.CheckReport(try? small_check_with_result(f, max_size, expect, abort)).render(
-    verbose~,
-  )
+  let result = try
+    small_check_with_result(f, max_size, expect, abort) |> Ok
+  catch {
+    error => Err(error)
+  }
+  @report.CheckReport(result).render(verbose~)
 }
 
 ///|
@@ -73,7 +79,17 @@ pub fn[A : Enumerable + Debug, B : Testable] small_check_error(
   abort? : Bool = false,
   verbose? : Bool = false,
 ) -> Unit raise Failure {
-  small_check(a => try? f(a), max_size~, expect~, abort~, verbose~)
+  small_check(
+    a => {
+      try f(a) |> Ok catch {
+        error => Err(error)
+      }
+    },
+    max_size~,
+    expect~,
+    abort~,
+    verbose~,
+  )
 }
 
 ///|
@@ -86,7 +102,17 @@ pub fn[A : Enumerable + Debug, B : Testable] small_check_error_silence(
   abort? : Bool = false,
   verbose? : Bool = false,
 ) -> String {
-  small_check_silence(a => try? f(a), max_size~, expect~, abort~, verbose~)
+  small_check_silence(
+    a => {
+      try f(a) |> Ok catch {
+        error => Err(error)
+      }
+    },
+    max_size~,
+    expect~,
+    abort~,
+    verbose~,
+  )
 }
 
 ///|

--- a/src/feat/small_check.mbt
+++ b/src/feat/small_check.mbt
@@ -172,7 +172,7 @@ fn[A : Enumerable + Debug, B : Testable] small_check_with_result(
   abort : Bool,
 ) -> @report.TestSuccess raise @report.TestError {
   let limit = if max_size < 0 { 0 } else { max_size }
-  let enumeration = A::enumerate()
+  let enumeration = Enumerable::enumerate()
   let mut st = @state.from_config({
     max_shrink: 0,
     max_success: limit,

--- a/src/gen/pkg.generated.mbti
+++ b/src/gen/pkg.generated.mbti
@@ -60,9 +60,7 @@ pub fn[T, U] tuple(Gen[T], Gen[U]) -> Gen[(T, U)]
 // Errors
 
 // Types and methods
-pub struct Gen[T] {
-  // private fields
-}
+type Gen[T]
 pub fn[T] Gen::Gen((Int, @splitmix.RandomState) -> T) -> Self[T]
 pub fn[T, U] Gen::ap(Self[(T) -> U], Self[T]) -> Self[U]
 pub fn[T] Gen::array_with_size(Self[T], Int) -> Self[Array[T]]

--- a/src/internal/benchmark/bm-curry-forall-tuple.mbt
+++ b/src/internal/benchmark/bm-curry-forall-tuple.mbt
@@ -27,15 +27,33 @@ let test_tuple : @qc.Arrow[(Array[Int], Array[Int]), Bool] = (p => {
 
 ///|
 test (b : @bench.T) {
-  b.bench(name="forall", () => b.keep(try? @qc.quick_check(test_forall)))
+  b.bench(name="forall", () => {
+    b.keep(
+      try @qc.quick_check(test_forall) |> Ok catch {
+        error => Err(error)
+      },
+    )
+  })
 }
 
 ///|
 test (b : @bench.T) {
-  b.bench(name="curry", () => b.keep(try? @qc.quick_check(test_curry)))
+  b.bench(name="curry", () => {
+    b.keep(
+      try @qc.quick_check(test_curry) |> Ok catch {
+        error => Err(error)
+      },
+    )
+  })
 }
 
 ///|
 test (b : @bench.T) {
-  b.bench(name="tuple", () => b.keep(try? @qc.quick_check(test_tuple)))
+  b.bench(name="tuple", () => {
+    b.keep(
+      try @qc.quick_check(test_tuple) |> Ok catch {
+        error => Err(error)
+      },
+    )
+  })
 }

--- a/src/internal/testing/feat.mbt
+++ b/src/internal/testing/feat.mbt
@@ -155,7 +155,7 @@ priv enum SingleTree {
 ///|
 impl @feat.Enumerable for SingleTree with fn enumerate() {
   @feat.consts(
-    @list.from_array([
+    List([
       @feat.Enumerable::enumerate().fmap(x => Leaf(x)),
       @feat.unary((p : (Bool, SingleTree)) => Node(p.0, p.1)),
     ]),

--- a/src/internal/testing/tutorial_en/README.mbt.md
+++ b/src/internal/testing/tutorial_en/README.mbt.md
@@ -434,7 +434,7 @@ For instance, you can use the `fmap` method to transform the generated value:
 
 ```mbt check
 ///|
-let g1 : @gen.Gen[Int] = @gen.Gen(
+let g1 : @gen.Gen[Int] = Gen(
   {
     ...
   },
@@ -451,7 +451,7 @@ Or create a dependent generator:
 
 ```mbt check
 ///|
-let dg1 : @gen.Gen[Int] = @gen.Gen(
+let dg1 : @gen.Gen[Int] = Gen(
   {
     ...
   },

--- a/src/internal/testing/tutorial_en/Tutorial1.mbt.md
+++ b/src/internal/testing/tutorial_en/Tutorial1.mbt.md
@@ -601,7 +601,7 @@ test "model-based testing for Set" {
     let (model_set, model_trace) = run_model(cmds)
     let (sut_set, sut_trace) = run_sut(cmds)
     let model_set_arr = model_set.0.sort()
-    let sut_set = @list.from_array(sut_set.to_array())
+    let sut_set = @list.List(sut_set.to_array())
     model_trace == sut_trace && model_set_arr == sut_set
   })
   @qc.quick_check(prop)

--- a/src/internal/testing/tutorial_en/Tutorial2.mbt.md
+++ b/src/internal/testing/tutorial_en/Tutorial2.mbt.md
@@ -523,7 +523,7 @@ fn gen_bst_ranged(min : Int, max : Int) -> @gen.Gen[Tree[Int]] {
       (1, @gen.pure(Leaf)),
       (
         4,
-        @gen.Gen((i, rs) => {
+        Gen((i, rs) => {
           let x = @gen.int_range(lo, hi).run(i, rs)
           let nL = @gen.int_range(0, n - 1).run(i, rs)
           let nR = n - 1 - nL

--- a/src/internal/testing/tutorial_zh/Tutorial1.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial1.mbt.md
@@ -675,7 +675,7 @@ test "model-based testing for Set" {
     let (model_set, model_trace) = run_model(cmds)
     let (sut_set, sut_trace) = run_sut(cmds)
     let model_set_arr = model_set.0.sort()
-    let sut_set = @list.from_array(sut_set.to_array())
+    let sut_set = @list.List(sut_set.to_array())
     model_trace == sut_trace && model_set_arr == sut_set
   })
   @qc.quick_check(prop)

--- a/src/internal/testing/tutorial_zh/Tutorial2.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial2.mbt.md
@@ -610,7 +610,7 @@ fn gen_bst_ranged(min : Int, max : Int) -> @gen.Gen[Tree[Int]] {
       (1, @gen.pure(Leaf)),
       (
         4,
-        @gen.Gen((i, rs) => {
+        Gen((i, rs) => {
           let x = @gen.int_range(lo, hi).run(i, rs)
           let nL = @gen.int_range(0, n - 1).run(i, rs)
           let nR = n - 1 - nL

--- a/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
+++ b/src/internal/testing/tutorial_zh/Tutorial3.mbt.md
@@ -524,8 +524,7 @@ enum Nat {
 ///|
 impl @feat.Enumerable for Nat with fn enumerate() {
   @feat.pay(() => {
-    @feat.singleton(Zero) +
-    @feat.Enumerable::enumerate().fmap(n => Nat::Succ(n))
+    @feat.singleton(Zero) + @feat.Enumerable::enumerate().fmap(n => Succ(n))
   })
 }
 

--- a/src/internal/utils/README.mbt.md
+++ b/src/internal/utils/README.mbt.md
@@ -113,7 +113,7 @@ test "removes_array walks in chunks of k" {
 ///|
 test "removes_list matches the chunk-wise semantics" {
   // Input  : [1, 2, 3, 4], k = 2 — only the first chunk has a non-empty tail.
-  let xs = @list.from_array([1, 2, 3, 4])
+  let xs = @list.List([1, 2, 3, 4])
   let variants = @utils.removes_list(2, 4, xs)
   debug_inspect(
     variants,

--- a/src/internal/utils/common.mbt
+++ b/src/internal/utils/common.mbt
@@ -38,7 +38,7 @@ pub fn fresh_name() -> String {
 ///
 /// ```mbt check
 /// test {
-///   let xs = @list.from_array([1, 2, 3, 4, 5, 6])
+///   let xs = @list.List([1, 2, 3, 4, 5, 6])
 ///   debug_inspect(
 ///     removes_list(2, 6, xs),
 ///     content=(

--- a/src/modifiers/collection.mbt
+++ b/src/modifiers/collection.mbt
@@ -64,7 +64,7 @@ pub impl[T : @coreqc.Arbitrary] @coreqc.Arbitrary for NonEmptyList[T] with fn ar
   rs,
 ) {
   let n = rs.next_positive_int() % (size + 1) + 1
-  NonEmptyList(@list.from_array(Array::makei(n, _ => T::arbitrary(size, rs))))
+  NonEmptyList(List(Array::makei(n, _ => T::arbitrary(size, rs))))
 }
 
 ///|
@@ -83,7 +83,7 @@ test "NonEmptyList[Int] generates non-empty lists" {
 
 ///|
 test "NonEmptyList[Int] shrinks without producing empty" {
-  let s = @shrink.Shrink::shrink(NonEmptyList(@list.from_array([1, 2, 3]))).to_array()
+  let s = @shrink.Shrink::shrink(NonEmptyList(List([1, 2, 3]))).to_array()
   assert_true(s.all(x => !x.0.is_empty()))
 }
 
@@ -151,7 +151,7 @@ pub impl[T : @coreqc.Arbitrary + Compare] @coreqc.Arbitrary for SortedList[T] wi
 ) {
   let arr : Array[T] = @coreqc.Arbitrary::arbitrary(size, rs)
   arr.sort()
-  SortedList(@list.from_array(arr))
+  SortedList(List(arr))
 }
 
 ///|
@@ -170,15 +170,12 @@ test "SortedList[Int] generates sorted lists" {
 
 ///|
 test "SortedList[Int] shrinks preserving sort" {
-  let s = @shrink.Shrink::shrink(SortedList(@list.from_array([1, 3, 5, 7]))).to_array()
+  let s = @shrink.Shrink::shrink(SortedList(List([1, 3, 5, 7]))).to_array()
   assert_true(s.all(x => x.0.to_array().is_sorted()))
   assert_true(s.length() > 0)
 }
 
 ///|
 test "SortedList[Int] debug output keeps wrapper name" {
-  debug_inspect(
-    SortedList(@list.from_array([1, 2, 3])),
-    content="<SortedList: [1, 2, 3]>",
-  )
+  debug_inspect(SortedList(List([1, 2, 3])), content="<SortedList: [1, 2, 3]>")
 }

--- a/src/property/testable.mbt
+++ b/src/property/testable.mbt
@@ -92,7 +92,11 @@ pub impl[P : Testable, A : @coreqc.Arbitrary + @shrink.Shrink + Debug] Testable 
   A,
   P,
 ] with fn property(self) {
-  forall_shrink(@gen.Gen::spawn(), A::shrink, (a : A) => try? (self.0)(a))
+  forall_shrink(@gen.Gen::spawn(), A::shrink, (a : A) => {
+    try (self.0)(a) |> Ok catch {
+      error => Err(error)
+    }
+  })
 }
 
 ///|

--- a/src/property/testable.mbt
+++ b/src/property/testable.mbt
@@ -82,7 +82,7 @@ pub impl[P : Testable, A : @coreqc.Arbitrary + @shrink.Shrink + Debug] Testable 
   A,
   P,
 ] with fn property(self) {
-  forall_shrink(@gen.Gen::spawn(), A::shrink, self.0)
+  forall_shrink(@gen.Gen::spawn(), @shrink.Shrink::shrink, self.0)
 }
 
 ///|
@@ -92,7 +92,7 @@ pub impl[P : Testable, A : @coreqc.Arbitrary + @shrink.Shrink + Debug] Testable 
   A,
   P,
 ] with fn property(self) {
-  forall_shrink(@gen.Gen::spawn(), A::shrink, (a : A) => {
+  forall_shrink(@gen.Gen::spawn(), @shrink.Shrink::shrink, (a : A) => {
     try (self.0)(a) |> Ok catch {
       error => Err(error)
     }

--- a/src/runner.mbt
+++ b/src/runner.mbt
@@ -6,8 +6,8 @@ fn @state.State::run_test(
   self : @state.State,
   prop : Property,
 ) -> @report.CheckReport {
-  CheckReport(
-    try? (for state = self {
+  try {
+    let result = for state = self {
       let rnd1 = state.random_state.split()
       let rnd2 = state.random_state
       let res = prop.run(state.compute_size(), rnd1)
@@ -51,6 +51,9 @@ fn @state.State::run_test(
           }
         }
       }
-    }),
-  )
+    }
+    CheckReport(Ok(result))
+  } catch {
+    error => CheckReport(Err(error))
+  }
 }

--- a/src/shrink/shrink.mbt
+++ b/src/shrink/shrink.mbt
@@ -250,7 +250,7 @@ pub impl[T : Shrink] Shrink for @list.List[T] with fn shrink(xs) {
 ///
 /// ```mbt check
 /// test {
-///   let xs : @list.List[Int] = @list.from_array([5])
+///   let xs : @list.List[Int] = List([5])
 ///   // Default list shrink would produce [], which is filtered out here.
 ///   assert_true(shrink_non_empty_list(xs).all(ys => !ys.is_empty()))
 /// }
@@ -361,7 +361,7 @@ pub fn[T : Shrink + Compare] shrink_sorted_list(
   lo~ : T,
   hi~ : T,
 ) -> Iter[@list.List[T]] {
-  shrink_sorted_array(xs.to_array(), lo~, hi~).map(a => @list.from_array(a))
+  shrink_sorted_array(xs.to_array(), lo~, hi~).map(a => List(a))
 }
 
 ///|

--- a/src/shrink/shrink.mbt
+++ b/src/shrink/shrink.mbt
@@ -379,7 +379,7 @@ pub fn[X : Shrink + Eq] shrink_distinct_array(xs : Array[X]) -> Iter[Array[X]] {
   let shrink_one_val = Array::makei(xs.length(), i => i)
     .iter()
     .flat_map(i => {
-      X::shrink(xs[i]).flat_map(x => {
+      Shrink::shrink(xs[i]).flat_map(x => {
         if x != xs[i] && no_duplicate_at(xs, i, x) {
           let nv = xs.copy()
           nv[i] = x
@@ -406,7 +406,7 @@ pub fn[T : Shrink + Compare] shrink_sorted_distinct_array(
     .flat_map(i => {
       let lower_ok = x => if i == 0 { lo <= x } else { nv[i - 1] < x }
       let upper_ok = x => if i == l { x <= hi } else { x < nv[i + 1] }
-      T::shrink(nv[i]).flat_map(x => {
+      Shrink::shrink(nv[i]).flat_map(x => {
         if lower_ok(x) && upper_ok(x) && x != nv[i] {
           let nv1 = nv.copy()
           nv1[i] = x

--- a/src/shrink/shrink_test.mbt
+++ b/src/shrink/shrink_test.mbt
@@ -190,7 +190,7 @@ test "shrink 6-tuple" {
 
 ///|
 test "shrink int list" {
-  let il : @list.List[Int] = @list.from_array([1, 2, 3, 4, 5, 6])
+  let il : @list.List[Int] = List([1, 2, 3, 4, 5, 6])
   let s = @shrink.Shrink::shrink(il)
   json_inspect(s, content=[
     [2, 3, 4, 5, 6],
@@ -218,7 +218,7 @@ test "shrink int list" {
 
 ///|
 test "shrink non-empty list" {
-  let il : @list.List[Int] = @list.from_array([1])
+  let il : @list.List[Int] = List([1])
   json_inspect(@shrink.shrink_non_empty_list(il), content=[[0]])
 }
 
@@ -333,7 +333,7 @@ test "shrink sorted distinct array" {
 
 ///|
 test "shrink sorted list" {
-  let xs : @list.List[Int] = @list.from_array([1, 3, 5])
+  let xs : @list.List[Int] = List([1, 3, 5])
   json_inspect(@shrink.shrink_sorted_list(xs, lo=0, hi=9), content=[
     [3, 5],
     [1, 5],


### PR DESCRIPTION
## Summary

- replace deprecated `try?` captures with explicit `Result` construction where the result must escape
- migrate deprecated list constructors and disambiguate empty map literals
- remove redundant constructor qualifiers in code and tested documentation

## Why

The latest MoonBit compiler reports 32 warnings for syntax and APIs that have become deprecated or ambiguous. These warnings make routine checks noisy and risk turning into future build failures.

## Impact

Builds are warning-free across all supported targets. Error-to-property conversion behavior is preserved, and generated public interfaces are unchanged.

## Validation

- `moon check --target all --warn-list +unnecessary_annotation --deny-warn --diagnostic-limit 1000`
- `moon test --target all --warn-list +unnecessary_annotation --diagnostic-limit 1000` (304 tests passed on each target)
- `moon fmt`
- `moon info` (no public API diff)
