### PR TITLE
refactor: use `[|...|]` iter literals instead of `[...].iter()`

### DIFF
--- a/src/internal/rose/README.mbt.md
+++ b/src/internal/rose/README.mbt.md
@@ -348,7 +348,7 @@ loop calls `<expr>.iter()`, you can use `Rose` directly with the loop sugar.
 ///|
 test "iter visits root then branches in DFS order" {
   let tree = @rose.Rose(1, [|
-    @rose.Rose(2, [|@rose.pure(3), @rose.pure(4)|]),
+    Rose(2, [|@rose.pure(3), @rose.pure(4)|]),
     Rose(5, [|@rose.pure(6)|]),
   |])
   @debug.assert_eq(tree.iter().collect(), [1, 2, 3, 4, 5, 6])

--- a/src/internal/rose/README.mbt.md
+++ b/src/internal/rose/README.mbt.md
@@ -145,7 +145,7 @@ test "pure is a leaf with no alternatives" {
 
 ///|
 test "new attaches explicit shrinks" {
-  let rose = @rose.Rose(3, [@rose.pure(0), @rose.pure(1), @rose.pure(2)].iter())
+  let rose = @rose.Rose(3, [|@rose.pure(0), @rose.pure(1), @rose.pure(2)|])
   assert_eq(rose.val, 3)
   let children = rose.branch.collect()
   assert_eq(children.length(), 3)
@@ -221,7 +221,7 @@ Pathological example — *don't construct trees like this*:
 // Children are LARGER than the parent. The driver, asked "is there
 // something smaller that still fails?", happily descends into 100,
 // then 100's "shrinks" (which would be even larger), and never stops.
-@rose.Rose(1, [@rose.pure(100), @rose.pure(200)].iter())
+@rose.Rose(1, [|@rose.pure(100), @rose.pure(200)|])
 ```
 
 The invariants aren't checked by the type system. You uphold them
@@ -266,7 +266,7 @@ Maps `f` over every node in the tree. Structure is preserved.
 ```mbt check
 ///|
 test "fmap relabels every node" {
-  let r = @rose.Rose(2, [@rose.pure(0), @rose.pure(1)].iter())
+  let r = @rose.Rose(2, [|@rose.pure(0), @rose.pure(1)|])
   let doubled = r.fmap(x => x * 10)
   assert_eq(doubled.val, 20)
   let children : Array[Int] = doubled.branch.map(c => c.val).collect()
@@ -284,7 +284,7 @@ after the new sub-trees.
 ```mbt check
 ///|
 test "bind substitutes at every node" {
-  let r = @rose.Rose(1, [@rose.pure(0)].iter())
+  let r = @rose.Rose(1, [|@rose.pure(0)|])
   // For every node n, emit a Rose that also has "n - 1" as an alternative.
   let expanded = r.bind(n => {
     Rose(
@@ -307,11 +307,10 @@ test "bind substitutes at every node" {
 ///|
 test "join flattens Rose[Rose[T]] into Rose[T]" {
   // Outer tree of Roses; the root already carries a Rose[Int].
-  let inner = @rose.Rose(10, [@rose.pure(5)].iter())
-  let outer : @rose.Rose[@rose.Rose[Int]] = Rose(
-    inner,
-    [@rose.pure(@rose.pure(7))].iter(),
-  )
+  let inner = @rose.Rose(10, [|@rose.pure(5)|])
+  let outer : @rose.Rose[@rose.Rose[Int]] = Rose(inner, [|
+    @rose.pure(@rose.pure(7)),
+  |])
   let flat = outer.join()
   // The root value is the root of the inner Rose.
   assert_eq(flat.val, 10)
@@ -331,7 +330,7 @@ decorate a generated tree.
 ```mbt check
 ///|
 test "apply rewrites a single node" {
-  let r = @rose.Rose(10, [@rose.pure(5), @rose.pure(0)].iter())
+  let r = @rose.Rose(10, [|@rose.pure(5), @rose.pure(0)|])
   // Collapse the tree: drop all branches, keep only the root.
   let collapsed = r.apply((v, _) => @rose.pure(v))
   assert_eq(collapsed.val, 10)
@@ -348,19 +347,16 @@ loop calls `<expr>.iter()`, you can use `Rose` directly with the loop sugar.
 ```mbt check
 ///|
 test "iter visits root then branches in DFS order" {
-  let tree = @rose.Rose(
-    1,
-    [
-      @rose.Rose(2, [@rose.pure(3), @rose.pure(4)].iter()),
-      Rose(5, [@rose.pure(6)].iter()),
-    ].iter(),
-  )
+  let tree = @rose.Rose(1, [|
+    @rose.Rose(2, [|@rose.pure(3), @rose.pure(4)|]),
+    Rose(5, [|@rose.pure(6)|]),
+  |])
   @debug.assert_eq(tree.iter().collect(), [1, 2, 3, 4, 5, 6])
 }
 
 ///|
 test "for .. in walks every value" {
-  let tree = @rose.Rose(10, [@rose.pure(20), @rose.pure(30)].iter())
+  let tree = @rose.Rose(10, [|@rose.pure(20), @rose.pure(30)|])
 
   @debug.assert_eq([ for x in tree => x ], [10, 20, 30])
 }

--- a/src/internal/rose/rose.mbt
+++ b/src/internal/rose/rose.mbt
@@ -70,7 +70,7 @@ pub fn[T] pure(val : T) -> Rose[T] {
 ///
 /// ```mbt check
 /// test {
-///   let tree = @rose.Rose(1, [pure(2), pure(3)].iter())
+///   let tree = @rose.Rose(1, [|pure(2), pure(3)|])
 ///   let doubled = tree.fmap(x => x * 2)
 ///   @debug.assert_eq(doubled.iter().collect(), [2, 4, 6])
 /// }
@@ -89,10 +89,7 @@ test "iter walks root then branches in depth-first order" {
   //     / \   \
   //    3   4   6
   let leaf = pure
-  let tree = Rose(
-    1,
-    [Rose(2, [leaf(3), leaf(4)].iter()), Rose(5, [leaf(6)].iter())].iter(),
-  )
+  let tree = Rose(1, [|Rose(2, [|leaf(3), leaf(4)|]), Rose(5, [|leaf(6)|])|])
 
   @debug.assert_eq([..tree], [1, 2, 3, 4, 5, 6])
 }
@@ -104,7 +101,7 @@ test "iter on a leaf yields only the root" {
 
 ///|
 test "for .. in sugar walks every value" {
-  let tree = Rose(10, [pure(20), pure(30)].iter())
+  let tree = Rose(10, [|pure(20), pure(30)|])
 
   @debug.assert_eq([ for x in tree => x ], [10, 20, 30])
 }

--- a/src/internal/rose/rose_test.mbt
+++ b/src/internal/rose/rose_test.mbt
@@ -74,10 +74,7 @@ test "find_min_failing skips passing siblings and follows the first failing bran
   //
   // Walk: 10 fails → first child 3 passes (skip) → second child 8 fails →
   // descend into 8 → only child 5 passes → 8 is the smallest failure.
-  let r = @rose.Rose(
-    10,
-    [@rose.pure(3), Rose(8, [@rose.pure(5)].iter())].iter(),
-  )
+  let r = @rose.Rose(10, [|@rose.pure(3), Rose(8, [|@rose.pure(5)|])|])
   debug_inspect(find_min_failing(r, x => x >= 6), content="Some(8)")
 }
 

--- a/src/internal/testing/driver.mbt
+++ b/src/internal/testing/driver.mbt
@@ -397,7 +397,7 @@ impl @coreqc.Arbitrary for Nat with fn arbitrary(i, rs) {
 impl Add for Nat with fn add(self, other) {
   match self {
     Zero => other
-    Succ(n) => Succ(n.add(other))
+    Succ(n) => Succ(Add::add(n, other))
   }
 }
 
@@ -619,7 +619,7 @@ test "small_check accepts Debug-only input" {
 test "collect accepts Debug-only labels" {
   inspect(
     @feat.small_check_silence(
-      fn(x : DebugOnly) { @qc.property(true).collect(x.to_repr()) },
+      fn(x : DebugOnly) { @qc.property(true).collect(@debug.repr(x)) },
       max_size=2,
     ),
     content=(

--- a/src/shrink/shrink.mbt
+++ b/src/shrink/shrink.mbt
@@ -92,7 +92,7 @@ pub impl Shrink for Char with fn shrink(c) {
     return Iter::empty()
   } else {
     let (cl, ch) = (Int::unsafe_to_char(ci - 1), Int::unsafe_to_char(ci + 1))
-    [cl, ch, 'a', 'A', '1', '\n', '\t', '\b', '\\', '\'', '\r', ' '].iter()
+    [|cl, ch, 'a', 'A', '1', '\n', '\t', '\b', '\\', '\'', '\r', ' '|]
   }
 }
 
@@ -118,15 +118,13 @@ pub impl Shrink for Float with fn shrink(x) {
 ///   strictly closer to zero is emitted, along with integer-shrink
 ///   candidates of the scaled mantissa.
 fn shrink_decimal(x : Double) -> Iter[Double] {
-  guard !x.is_nan() else { [0.0, 1.0, -1.0, 2.0].iter() }
-  guard !x.is_inf() else { [0.0, 1.0, -1.0, 1000.0, -1000.0].iter() }
+  guard !x.is_nan() else { [|0.0, 1.0, -1.0, 2.0|] }
+  guard !x.is_inf() else { [|0.0, 1.0, -1.0, 1000.0, -1000.0|] }
   guard x >= 0.0 else {
     Iter::singleton(-x).concat(shrink_decimal(-x).map(Double::neg))
   }
   guard x != 0.0 else { Iter::empty() }
-  [1.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0]
-  .iter()
-  .flat_map(p => {
+  [|1.0, 10.0, 100.0, 1000.0, 10000.0, 100000.0|].flat_map(p => {
     let m = (x * p + 0.5).floor().to_int64()
     if p != 1.0 && m % 10L == 0L {
       return Iter::empty()

--- a/src/shrink/shrink_test.mbt
+++ b/src/shrink/shrink_test.mbt
@@ -257,7 +257,7 @@ test "shrink non-empty array" {
 
 ///|
 test "shrink iter" {
-  let it = [1, 2, 3, 4, 5, 6].iter()
+  let it = [|1, 2, 3, 4, 5, 6|]
   json_inspect(@shrink.Shrink::shrink(it), content=[
     [2, 3, 4, 5, 6],
     [1, 3, 4, 5, 6],


### PR DESCRIPTION
## Summary

Replace every array literal that is immediately consumed by `.iter()` with the dedicated iter-literal syntax `[|...|]`:

- `src/shrink/shrink.mbt` — char shrink candidates, the NaN/Inf fallbacks in `shrink_decimal`, and the rounding-precision literal
- `src/shrink/shrink_test.mbt` — "shrink iter" test
- `src/internal/rose/rose.mbt` — `fmap` doc example and DFS test
- `src/internal/rose/rose_test.mbt` — `find_min_failing` test
- `src/internal/rose/README.mbt.md` — literate examples

Chained `.iter()` calls on non-literals (`Array::makei(...)`, `.map(...)` results) are intentionally left unchanged.

## Test plan

- [x] `moon test` — 304/304 passed
- [x] `moon check --target js,native,wasm,wasm-gc` — 0 errors (3 pre-existing deprecation warnings, unrelated)
- [x] `moon fmt` — clean